### PR TITLE
Add RecordIterator to public interface.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ mod record;
 mod writing;
 
 pub use crate::error::{Error, ErrorKind, FieldIOError};
-pub use crate::reading::{read, FieldIterator, NamedValue, ReadableRecord, Reader, Record};
+pub use crate::reading::{read, FieldIterator, NamedValue, ReadableRecord, Reader, Record, RecordIterator};
 pub use crate::record::field::{Date, DateTime, FieldValue, Time};
 pub use crate::record::{FieldConversionError, FieldInfo, FieldName};
 pub use crate::writing::{FieldWriter, TableWriter, TableWriterBuilder, WritableRecord};


### PR DESCRIPTION
RecordIterator is not exposed on the public interface, preventing e.g. having a RecordIterator as a struct field:

`struct MyStruct {
    dbase::RecordIterator<BufReader<File>>,
}`

This pull requests adds RecordIterator to the exposed interface on the crate.