### PR TITLE
Reader is now Clone

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -111,7 +111,7 @@ impl From<u8> for Version {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct TableFlags(u8);
 
 impl TableFlags {
@@ -130,7 +130,7 @@ impl TableFlags {
 
 /// Definition of the header struct stored at the beginning
 /// of each dBase file
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Header {
     pub file_type: Version,
     pub last_update: Date,

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -111,6 +111,7 @@ impl From<HashMap<String, FieldValue>> for Record {
 
 /// Struct with the handle to the source .dbf file
 /// Responsible for reading the content
+#[derive(Clone, Debug)]
 pub struct Reader<T: Read + Seek> {
     /// Where the data is read from
     source: T,
@@ -318,7 +319,7 @@ impl<'a, T: Read + Seek> FieldIterator<'a, T> {
         let field_info = self
             .fields_info
             .next()
-            .ok_or(FieldIOError::end_of_record())?;
+            .ok_or_else(|| { FieldIOError::end_of_record() })?;
         if field_info.is_deletion_flag() {
             if let Err(e) = self.skip_field(field_info) {
                 Err(FieldIOError {

--- a/src/record/field.rs
+++ b/src/record/field.rs
@@ -54,7 +54,7 @@ impl MemoHeader {
 }
 
 /// Struct that reads knows how to read data from a memo source
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct MemoReader<T: Read + Seek> {
     memo_file_type: MemoFileType,
     header: MemoHeader,
@@ -229,7 +229,7 @@ impl std::fmt::Display for FieldType {
 }
 
 /// Enum where each variant stores the record value
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FieldValue {
     // dBase III fields
     // Stored as strings, fully padded (ie only space char) strings

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -258,7 +258,7 @@ impl TryFrom<FieldValue> for f64 {
     fn try_from(value: FieldValue) -> Result<Self, Self::Error> {
         match value {
             FieldValue::Numeric(Some(v)) => Ok(v),
-            FieldValue::Numeric(None) => Err(FieldConversionError::NoneValue.into()),
+            FieldValue::Numeric(None) => Err(FieldConversionError::NoneValue),
             FieldValue::Currency(c) => Ok(c),
             FieldValue::Double(d) => Ok(d),
             _ => Err(FieldConversionError::IncompatibleType),


### PR DESCRIPTION
I was trying to update `shapefile` to use `dbase` 0.1.0 but in debugging some issue there, I noticed that `Reader` wasn't clone but could be.

I also fixed 2 minor things that Clippy pointed out.

If this pull request is accepted, it may be worth it to push out a new version of the crate (#9 isn't available on Cargo, for example)