### PR TITLE
fix reader offset issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 support/
 *.dbf
 .DS_Store
+.vscode


### PR DESCRIPTION
Fixes #11 by ensuring the source cursor for a new reader is at position = header.offset_to_first_record. Previously, this wasn't guaranteed.