### PR TITLE
Allow the writing of records one  by one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Unreleased
+    - Added a `seek` method to the `Reader`
+    - Added a `TableInfo` struct and a `into_table_info` method on the `Reader`.
+      This `TableInfo` contains informations that can be used to create a new `TableWriterBuilder`
+      that writes a dbf file with same 'layout' as the file from which the `TableInfo` comes from.
+    - Added `TableWriterBuilder::from_table_info`
+    - Changed `TableWriter::write` is now named `TableWriter::write_records` and takes any type that
+      implements `IntoIterator<Item=&RecordType>` (so &[RecordType] is still a valid input).
+    - Changed `TableWriter<T>` now requires `T` to implement `std::io::Seek and std::io::Read`,
+      both `std::fs::File` & `std::io::Cursor` are example of valid `T`.
+    - Added `TableWriter::write_record` to be able to write one record at a time.
+    
+    
+
 # 0.1.2
     - Fixed some files not being properly read, by ensuring the reader seeks to the begining
       of the records after reading the header. (issue #11, Pull Request #12)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@
 //!     .build_with_file_dest("stations.dbf").unwrap();
 //!
 //! stations[0].get_mut("line").and_then(|_old| Some("Red".to_string()));
-//! writer.write(&stations)?;
+//! writer.write_records(&stations)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -175,7 +175,7 @@
 //!     age: 32.0,
 //! }];
 //!
-//! writer.write(&records);
+//! writer.write_records(&records);
 //! ```
 //!
 //! If you use the serde optional feature and serde_derive crate you can have the
@@ -211,7 +211,7 @@
 //!     age: 32.0,
 //! }];
 //!
-//!     writer.write(&records);
+//!     writer.write_records(&records);
 //! # }
 //! # #[cfg(not(feature = "serde"))]
 //! # fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,18 +164,18 @@
 //!     }
 //! }
 //!
-//! let writer = TableWriterBuilder::new()
+//! let mut writer = TableWriterBuilder::new()
 //!     .add_character_field(FieldName::try_from("Nick Name").unwrap(), 50)
 //!     .add_numeric_field(FieldName::try_from("Age").unwrap(), 20, 10)
 //!     .build_with_dest(Cursor::new(Vec::<u8>::new()));
 //!
 //!
-//! let records = vec![User{
+//! let records = User{
 //!     nick_name: "Yoshi".to_string(),
 //!     age: 32.0,
-//! }];
+//! };
 //!
-//! writer.write_records(&records);
+//! writer.write_record(&records);
 //! ```
 //!
 //! If you use the serde optional feature and serde_derive crate you can have the

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -203,8 +203,10 @@ impl TableWriterBuilder {
     pub fn build_with_file_dest<P: AsRef<Path>>(
         self,
         path: P,
-    ) -> std::io::Result<TableWriter<BufWriter<File>>> {
-        let dst = BufWriter::new(File::create(path)?);
+    ) -> Result<TableWriter<BufWriter<File>>, Error> {
+        let file = File::create(path)
+            .map_err(|err| Error::io_error(err, 0))?;
+        let dst = BufWriter::new(file);
         Ok(self.build_with_dest(dst))
     }
 

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -449,6 +449,27 @@ impl<W: Write + Seek> TableWriter<W> {
         }
     }
 
+    /// Writes a record the inner destination
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::convert::TryFrom;
+    ///
+    /// # fn main() -> Result<(), dbase::Error> {
+    /// let mut writer = dbase::TableWriterBuilder::new()
+    ///     .add_character_field(dbase::FieldName::try_from("First Name").unwrap(), 50)
+    ///     .build_with_file_dest("records.dbf")?;
+    ///
+    /// let mut record = dbase::Record::default();
+    /// record.insert("First Name".to_string(), dbase::FieldValue::Character(Some("Yoshi".to_string())));
+    ///
+    /// writer.write_record(&record)?;
+    ///
+    /// # let ignored_result = std::fs::remove_file("record.dbf");
+    /// Ok(())
+    /// # }
+    /// ```
     pub fn write_record<R: WritableRecord>(&mut self, record: &R) -> Result<(), Error> {
         if self.header.num_records == 0 {
             // reserve the header
@@ -523,6 +544,12 @@ impl<W: Write + Seek> TableWriter<W> {
         Ok(())
     }
 
+    /// Close the writer
+    ///
+    /// Automatically closed when the writer is dropped,
+    /// use it if you want to handle error that can happen when the writer is closing
+    ///
+    /// Calling close on an already closed writer is a no-op
     fn close(&mut self) -> Result<(), Error> {
         if !self.closed {
             self.dst.seek(SeekFrom::Start(0))

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -16,9 +16,10 @@ mod serde_tests {
         records: &Vec<R>,
         writer_builder: TableWriterBuilder,
     ) {
-        let writer = writer_builder.build_with_dest(Cursor::new(Vec::<u8>::new()));
+        let mut dst = Cursor::new(Vec::<u8>::new());
+        let writer = writer_builder.build_with_dest(&mut dst);
 
-        let mut dst = writer.write(records).unwrap();
+        writer.write_records(records).unwrap();
         dst.set_position(0);
 
         let mut reader = Reader::new(dst).unwrap();
@@ -139,7 +140,7 @@ mod serde_tests {
             .add_character_field(FieldName::try_from("not present").unwrap(), 50)
             .build_with_dest(Cursor::new(Vec::<u8>::new()));
 
-        let error = writer.write(&records).expect_err("We expected an Error");
+        let error = writer.write_records(&records).expect_err("We expected an Error");
         match error.kind() {
             ErrorKind::NotEnoughFields => assert!(true),
             _ => assert!(false),
@@ -157,7 +158,7 @@ mod serde_tests {
 
         let writer = TableWriterBuilder::new().build_with_dest(Cursor::new(Vec::<u8>::new()));
 
-        let error = writer.write(&records).expect_err("Expected an error");
+        let error = writer.write_records(&records).expect_err("Expected an error");
 
         match error.kind() {
             ErrorKind::TooManyFields => assert!(true),


### PR DESCRIPTION
Refactor the TableWriter to be able to write one record at a time.

Add a `write_record` method to write one record (callable many time)
Rename `write` to `write_records` and change its arguments from `&[Record]` to `IntoIterator<&Record>`

- [x] Docs
- [x] Changelog