### PR TITLE
Improves performance of reading large dbfs

### DIFF
--- a/src/reading.rs
+++ b/src/reading.rs
@@ -95,7 +95,6 @@ impl IntoIterator for Record {
     }
 }
 
-
 impl From<HashMap<String, FieldValue>> for Record {
     fn from(map: HashMap<String, FieldValue, RandomState>) -> Self {
         Self { map }


### PR DESCRIPTION
This commit improves the way the values are read from the dbf files
improving the speed of the file processing by almost 3 times.

The key points of improvement:

* Removes `Vector::resize()` call in `read_string_of_len` function.
  Using `vec![0; len]` instead gives significant improvement.

* Instead of using `String::trim()` on the read values (to remove
  spaces) we first skip the empty bytes, and then convert the value
  into the string. Removing `trim` calls improves performance almost
  doublefold.

* Using unchecked indexing on the vector when trimming spaces
  provides ~30% improvement in comparison to the safe version.
  Using unsafe here is not strictly necessary, but the logic in
  the unsafe block is quite straitforward so it should be ok.

Overall in my case reading a 500 MiB dbf file takes:

* 1 min 20 sec before change

* 34 sec after change