### PR TITLE
Use a buffer to read record data

### DIFF
--- a/src/reading.rs
+++ b/src/reading.rs
@@ -95,7 +95,6 @@ impl IntoIterator for Record {
     }
 }
 
-
 impl From<HashMap<String, FieldValue>> for Record {
     fn from(map: HashMap<String, FieldValue, RandomState>) -> Self {
         Self { map }

--- a/src/record/field.rs
+++ b/src/record/field.rs
@@ -260,9 +260,9 @@ pub enum FieldValue {
 }
 
 impl FieldValue {
-    pub(crate) fn read_from<T: Read + Seek>(
-        mut source: &mut T,
-        memo_reader: &mut Option<MemoReader<T>>,
+    pub(crate) fn read_from<T1: Read + Seek, T2: Read + Seek>(
+        mut source: &mut T1,
+        memo_reader: &mut Option<MemoReader<T2>>,
         field_info: &FieldInfo,
     ) -> Result<Self, ErrorKind> {
         let value = match field_info.field_type {
@@ -942,7 +942,9 @@ mod test {
 
         out.set_position(0);
 
-        let read_value = FieldValue::read_from(&mut out, &mut None, field_info).unwrap();
+        let read_value =
+            FieldValue::read_from::<_, std::io::Cursor<Vec<u8>>>(&mut out, &mut None, field_info)
+                .unwrap();
         assert_eq!(value, &read_value);
     }
 


### PR DESCRIPTION
The RecordIterator now has a buffer where we first read the whole record into it
before handing it to the FieldIterator.

This improve reading performance by substantial amount, for a 1.3GB file,
without this change it take ~1min10 secs to read the file, with this change
it takes ~28 secs

related to #22 