### PR TITLE
Fix record size written in header

### DIFF
--- a/src/writing.rs
+++ b/src/writing.rs
@@ -545,7 +545,7 @@ impl<W: Write + Seek> TableWriter<W> {
         let size_of_record = self
             .fields_info
             .iter()
-            .fold(0u16, |s, ref info| s + info.field_length as u16);
+            .fold(1u16, |s, ref info| s + info.field_length as u16);
 
         self.header.offset_to_first_record = offset_to_first_record as u16;
         self.header.size_of_record = size_of_record;


### PR DESCRIPTION
We did not account for the `deletion flag` flag that is one byte long
and present before every record in the record size written in the header.

Without this our files are invalid

Fixes #26 