### PR TITLE
replace chrono with time; fix some things clippy was upset about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Next
+    - Replaced `chrono` with `time` v0.3
+
 # 0.2.3
     - Added `impl std::error::Error for dbase::Error`
     - Fixed deserialization implementation that would fail to deserialize if one `None`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = "1.4.3"
-chrono = "0.4"
+time = {version = "0.3", features=["std"]}
 serde = {version = "1.0.102", optional = true}
 
 [dev-dependencies]

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,5 +1,3 @@
-use chrono;
-
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use std::io::{Read, Write};
@@ -45,10 +43,7 @@ impl Version {
     }
 
     pub(crate) fn is_visual_fox_pro(self) -> bool {
-        match self {
-            Version::VisualFoxPro => true,
-            _ => false,
-        }
+        matches!(self, Version::VisualFoxPro)
     }
 }
 
@@ -158,18 +153,18 @@ impl Header {
             size_of_record: size_of_records,
             is_transaction_incomplete: false,
             encryption_flag: 0,
-            table_flags: TableFlags { 0: 0 },
+            table_flags: TableFlags(0),
             code_page_mark: 0,
         }
     }
 
     fn get_today_date() -> Date {
-        let current_date: Date = chrono::Utc::now().date().into();
+        let current_date = time::OffsetDateTime::now_utc().date();
         // The year will be saved a a u8 offset from 1900
         if current_date.year() < 1900 || current_date.year() > 2155 {
             panic!("the year current date is out of range");
         } else {
-            current_date
+            current_date.into()
         }
     }
 
@@ -200,9 +195,7 @@ impl Header {
         let mut _reserved = [0u8; 12];
         source.read_exact(&mut _reserved)?;
 
-        let table_flags = TableFlags {
-            0: source.read_u8()?,
-        };
+        let table_flags = TableFlags(source.read_u8()?);
 
         let code_page_mark = source.read_u8()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,9 +220,9 @@
 #![deny(unstable_features)]
 
 extern crate byteorder;
-extern crate chrono;
 #[cfg(feature = "serde")]
 extern crate serde;
+extern crate time;
 
 #[cfg(feature = "serde")]
 mod de;

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -379,7 +379,7 @@ impl<'a, T: Read + Seek> FieldIterator<'a, T> {
         let field_info = self
             .fields_info
             .next()
-            .ok_or_else(|| FieldIOError::end_of_record())?;
+            .ok_or_else(FieldIOError::end_of_record)?;
         if field_info.is_deletion_flag() {
             if let Err(e) = self.skip_field(field_info) {
                 Err(e)

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -34,9 +34,7 @@ impl TryFrom<&str> for FieldName {
         if name.as_bytes().len() > FIELD_NAME_LENGTH {
             Err("FieldName byte representation cannot exceed 11 bytes")
         } else {
-            Ok(Self {
-                0: name.to_string(),
-            })
+            Ok(Self(name.to_string()))
         }
     }
 }
@@ -95,9 +93,7 @@ impl FieldInfo {
         let record_length = source.read_u8()?;
         let num_decimal_places = source.read_u8()?;
 
-        let flags = FieldFlags {
-            0: source.read_u8()?,
-        };
+        let flags = FieldFlags(source.read_u8()?);
 
         let mut autoincrement_next_val = [0u8; 5];
 
@@ -152,7 +148,7 @@ impl FieldInfo {
             displacement_field: [0u8; 4],
             field_length: 1,
             num_decimal_places: 0,
-            flags: FieldFlags { 0: 0u8 },
+            flags: FieldFlags(0u8),
             autoincrement_next_val: [0u8; 5],
             autoincrement_step: 0u8,
         }
@@ -174,14 +170,8 @@ impl std::fmt::Display for FieldInfo {
 }
 
 /// Flags describing a field
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub(crate) struct FieldFlags(u8);
-
-impl Default for FieldFlags {
-    fn default() -> Self {
-        Self { 0: 0 }
-    }
-}
 
 /// Errors that can happen when trying to convert a FieldValue into
 /// a more concrete type

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -545,7 +545,7 @@ impl<W: Write + Seek> TableWriter<W> {
         let size_of_record = self
             .fields_info
             .iter()
-            .fold(1u16, |s, ref info| s + info.field_length as u16);
+            .fold(1u16, |s, info| s + info.field_length as u16);
 
         self.header.offset_to_first_record = offset_to_first_record as u16;
         self.header.size_of_record = size_of_record;


### PR DESCRIPTION
Fixes #34 

This will require a major version bump.

If we want to keep compatibility for users who are stuck on `chrono`, I could imagine putting in a `chrono` feature flag that would gate the relevant impls.