### PR TITLE
Add support for writing file with a given encoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,8 +178,8 @@
 //! # }
 //! ```
 //!
-//! ```
-//! use dbase::{TableWriterBuilder, FieldName, WritableRecord, FieldWriter, FieldIOError};
+//!```
+//! use dbase::{TableWriterBuilder, FieldName, WritableRecord, FieldWriter, FieldIOError, Encoding};
 //! use std::convert::TryFrom;
 //! use std::io::{Cursor, Write};
 //!
@@ -189,7 +189,9 @@
 //! }
 //!
 //! impl WritableRecord for User {
-//!     fn write_using<'a, W: Write>(&self, field_writer: &mut FieldWriter<'a, W>) -> Result<(), FieldIOError> {
+//!     fn write_using<'a, W, E>(&self, field_writer: &mut FieldWriter<'a, W, E>) -> Result<(), FieldIOError>
+//!         where W: Write,
+//!               E: Encoding, {
 //!         field_writer.write_next_field_value(&self.nick_name)?;
 //!         field_writer.write_next_field_value(&self.age)?;
 //!         Ok(())
@@ -261,6 +263,9 @@ mod de;
 #[cfg(feature = "serde")]
 mod ser;
 
+#[cfg(feature = "yore")]
+pub use yore;
+
 mod encoding;
 mod error;
 mod header;
@@ -324,7 +329,9 @@ macro_rules! dbase_record {
         }
 
        impl dbase::WritableRecord for $name {
-           fn write_using<'a, W: std::io::Write>(&self, field_writer: &mut dbase::FieldWriter<'a, W>) -> Result<(), dbase::FieldIOError> {
+           fn write_using<'a, W, E>(&self, field_writer: &mut dbase::FieldWriter<'a, W, E>) -> Result<(), dbase::FieldIOError>
+           where W: std::io::Write,
+                 E: $crate::Encoding{
                 $(
                     field_writer.write_next_field_value(&self.$field_name)?;
                 )+

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -3,22 +3,22 @@ use std::io::Write;
 
 use crate::record::field::FieldType;
 use crate::writing::FieldWriter;
-use crate::{Date, FieldIOError};
+use crate::{Date, Encoding, FieldIOError};
 use crate::{ErrorKind, WritableRecord};
 
 impl<T> WritableRecord for T
 where
     T: Serialize,
 {
-    fn write_using<'a, W: Write>(
+    fn write_using<'a, W: Write, E: Encoding>(
         &self,
-        field_writer: &mut FieldWriter<'a, W>,
+        field_writer: &mut FieldWriter<'a, W, E>,
     ) -> Result<(), FieldIOError> {
         self.serialize(field_writer)
     }
 }
 
-impl<'a, W: Write> Serializer for &mut FieldWriter<'a, W> {
+impl<'a, W: Write, E: Encoding> Serializer for &mut FieldWriter<'a, W, E> {
     type Ok = ();
     type Error = FieldIOError;
     type SerializeSeq = Self;
@@ -212,7 +212,7 @@ impl<'a, W: Write> Serializer for &mut FieldWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write> serde::ser::SerializeStructVariant for &mut FieldWriter<'a, W> {
+impl<'a, W: Write, E: Encoding> serde::ser::SerializeStructVariant for &mut FieldWriter<'a, W, E> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -232,7 +232,7 @@ impl<'a, W: Write> serde::ser::SerializeStructVariant for &mut FieldWriter<'a, W
     }
 }
 
-impl<'a, W: Write> serde::ser::SerializeStruct for &mut FieldWriter<'a, W> {
+impl<'a, W: Write, E: Encoding> serde::ser::SerializeStruct for &mut FieldWriter<'a, W, E> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -252,7 +252,7 @@ impl<'a, W: Write> serde::ser::SerializeStruct for &mut FieldWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write> serde::ser::SerializeSeq for &mut FieldWriter<'a, W> {
+impl<'a, W: Write, E: Encoding> serde::ser::SerializeSeq for &mut FieldWriter<'a, W, E> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -268,7 +268,7 @@ impl<'a, W: Write> serde::ser::SerializeSeq for &mut FieldWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write> serde::ser::SerializeMap for &mut FieldWriter<'a, W> {
+impl<'a, W: Write, E: Encoding> serde::ser::SerializeMap for &mut FieldWriter<'a, W, E> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -291,7 +291,7 @@ impl<'a, W: Write> serde::ser::SerializeMap for &mut FieldWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write> serde::ser::SerializeTupleVariant for &mut FieldWriter<'a, W> {
+impl<'a, W: Write, E: Encoding> serde::ser::SerializeTupleVariant for &mut FieldWriter<'a, W, E> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -307,7 +307,7 @@ impl<'a, W: Write> serde::ser::SerializeTupleVariant for &mut FieldWriter<'a, W>
     }
 }
 
-impl<'a, W: Write> serde::ser::SerializeTupleStruct for &mut FieldWriter<'a, W> {
+impl<'a, W: Write, E: Encoding> serde::ser::SerializeTupleStruct for &mut FieldWriter<'a, W, E> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -323,7 +323,7 @@ impl<'a, W: Write> serde::ser::SerializeTupleStruct for &mut FieldWriter<'a, W> 
     }
 }
 
-impl<'a, W: Write> serde::ser::SerializeTuple for &mut FieldWriter<'a, W> {
+impl<'a, W: Write, E: Encoding> serde::ser::SerializeTuple for &mut FieldWriter<'a, W, E> {
     type Ok = ();
     type Error = FieldIOError;
 

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -9,13 +9,16 @@ mod serde_tests {
 
     use serde_derive::{Deserialize, Serialize};
 
-    use dbase::{ErrorKind, FieldName, ReadableRecord, Reader, TableWriterBuilder, WritableRecord};
+    use dbase::{
+        Encoding, ErrorKind, FieldName, ReadableRecord, Reader, TableWriterBuilder, WritableRecord,
+    };
     use std::fmt::Debug;
 
-    fn write_read_compare<R: WritableRecord + ReadableRecord + Debug + PartialEq>(
-        records: &Vec<R>,
-        writer_builder: TableWriterBuilder,
-    ) {
+    fn write_read_compare<R, E>(records: &Vec<R>, writer_builder: TableWriterBuilder<E>)
+    where
+        R: WritableRecord + ReadableRecord + Debug + PartialEq,
+        E: Encoding,
+    {
         let mut dst = Cursor::new(Vec::<u8>::new());
         let writer = writer_builder.build_with_dest(&mut dst);
 


### PR DESCRIPTION
- Add support for writing with given encoding, code page support via `yore` crate
- Fix writing of visual fox pro file (the backlink was not written, we actually don't write it, but we pad with zeros)
- Breaking changes since the Encoding appears in type signatures
