### PR TITLE
Remove encoding from type parameters

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -5,11 +5,10 @@ use serde::de::{DeserializeOwned, DeserializeSeed, IntoDeserializer, SeqAccess, 
 use serde::Deserializer;
 
 use crate::{
-    Encoding, ErrorKind, FieldConversionError, FieldIOError, FieldIterator, FieldValue,
-    ReadableRecord,
+    ErrorKind, FieldConversionError, FieldIOError, FieldIterator, FieldValue, ReadableRecord,
 };
 
-impl<'de, 'a, 'f, R: Read + Seek, E: Encoding> SeqAccess<'de> for &mut FieldIterator<'a, R, E> {
+impl<'de, 'a, 'f, R: Read + Seek> SeqAccess<'de> for &mut FieldIterator<'a, R> {
     type Error = FieldIOError;
 
     fn next_element_seed<T>(
@@ -28,7 +27,7 @@ impl<'de, 'a, 'f, R: Read + Seek, E: Encoding> SeqAccess<'de> for &mut FieldIter
 }
 
 //TODO maybe we can deserialize numbers other than f32 & f64 by converting using TryFrom
-impl<'de, 'a, 'f, T: Read + Seek, E: Encoding> Deserializer<'de> for &mut FieldIterator<'a, T, E> {
+impl<'de, 'a, 'f, T: Read + Seek> Deserializer<'de> for &mut FieldIterator<'a, T> {
     type Error = FieldIOError;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
@@ -325,10 +324,9 @@ impl<'de, 'a, 'f, T: Read + Seek, E: Encoding> Deserializer<'de> for &mut FieldI
 }
 
 impl<S: DeserializeOwned> ReadableRecord for S {
-    fn read_using<T, E>(field_iterator: &mut FieldIterator<T, E>) -> Result<Self, FieldIOError>
+    fn read_using<T>(field_iterator: &mut FieldIterator<T>) -> Result<Self, FieldIOError>
     where
         T: Read + Seek,
-        E: Encoding,
     {
         S::deserialize(field_iterator)
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -4,6 +4,46 @@ use crate::error::{DecodeError, EncodeError};
 use std::borrow::Cow;
 use std::fmt::Debug;
 
+pub trait AsCodePageMark {
+    fn code_page_mark(&self) -> crate::CodePageMark;
+}
+
+macro_rules! impl_as_code_page_mark {
+    ($($t:ty => $cp:path),* $(,)?) => {
+        $(
+            impl AsCodePageMark for $t {
+                fn code_page_mark(&self) -> crate::CodePageMark {
+                    $cp
+                }
+            }
+        )*
+    };
+}
+
+impl_as_code_page_mark!(
+  Ascii => crate::CodePageMark::Utf8,
+  UnicodeLossy => crate::CodePageMark::Utf8,
+  Unicode => crate::CodePageMark::Utf8,
+);
+
+#[cfg(feature = "yore")]
+impl_as_code_page_mark!(
+    yore::code_pages::CP437 => crate::CodePageMark::CP437,
+    yore::code_pages::CP850 => crate::CodePageMark::CP850,
+    yore::code_pages::CP1252 => crate::CodePageMark::CP1252,
+    yore::code_pages::CP852 => crate::CodePageMark::CP852,
+    yore::code_pages::CP866 => crate::CodePageMark::CP866,
+    yore::code_pages::CP865 => crate::CodePageMark::CP865,
+    yore::code_pages::CP861 => crate::CodePageMark::CP861,
+    yore::code_pages::CP874 => crate::CodePageMark::CP874,
+    yore::code_pages::CP1255 => crate::CodePageMark::CP1255,
+    yore::code_pages::CP1256 => crate::CodePageMark::CP1256,
+    yore::code_pages::CP1250 => crate::CodePageMark::CP1250,
+    yore::code_pages::CP1251 => crate::CodePageMark::CP1251,
+    yore::code_pages::CP1254 => crate::CodePageMark::CP1254,
+    yore::code_pages::CP1253 => crate::CodePageMark::CP1253,
+);
+
 /// Trait for reading strings from the database files.
 ///
 /// If the `yore` feature isn't on, this is implemented only by [`UnicodeLossy`] and [`Unicode`].
@@ -11,13 +51,14 @@ use std::fmt::Debug;
 /// If the `yore` feature is on, this is implemented by all [`yore::CodePage`].
 ///
 /// Note: This trait might be extended with an `encode` function in the future.
-pub trait Encoding: EncodingClone {
+pub trait Encoding: EncodingClone + AsCodePageMark {
     /// Decode encoding into UTF-8 string. If codepoints can't be represented, an error is returned.
     fn decode<'a>(&self, bytes: &'a [u8]) -> Result<Cow<'a, str>, DecodeError>;
 
     fn encode<'a>(&self, s: &'a str) -> Result<Cow<'a, [u8]>, EncodeError>;
 }
 
+/// Trait to be able to clone a Box<dyn Encoding>
 pub trait EncodingClone {
     fn clone_box(&self) -> Box<dyn Encoding>;
 }
@@ -106,6 +147,12 @@ impl DynEncoding {
     }
 }
 
+impl AsCodePageMark for DynEncoding {
+    fn code_page_mark(&self) -> crate::CodePageMark {
+        self.inner.code_page_mark()
+    }
+}
+
 impl Encoding for DynEncoding {
     fn decode<'a>(&self, bytes: &'a [u8]) -> Result<Cow<'a, str>, DecodeError> {
         self.inner.decode(bytes)
@@ -119,7 +166,7 @@ impl Encoding for DynEncoding {
 #[cfg(feature = "yore")]
 impl<T> Encoding for T
 where
-    T: 'static + yore::CodePage + Clone,
+    T: 'static + yore::CodePage + Clone + AsCodePageMark,
 {
     fn decode<'a>(&self, bytes: &'a [u8]) -> Result<Cow<'a, str>, DecodeError> {
         self.decode(bytes).map_err(Into::into)
@@ -127,5 +174,33 @@ where
 
     fn encode<'a>(&self, s: &'a str) -> Result<Cow<'a, [u8]>, EncodeError> {
         self.encode(s).map_err(Into::into)
+    }
+}
+
+#[cfg(feature = "yore")]
+#[derive(Copy, Clone)]
+pub struct LossyCodePage<CP>(pub CP);
+
+#[cfg(feature = "yore")]
+impl<CP> AsCodePageMark for LossyCodePage<CP>
+where
+    CP: AsCodePageMark,
+{
+    fn code_page_mark(&self) -> crate::CodePageMark {
+        self.0.code_page_mark()
+    }
+}
+
+#[cfg(feature = "yore")]
+impl<CP> Encoding for LossyCodePage<CP>
+where
+    CP: 'static + yore::CodePage + Clone + AsCodePageMark,
+{
+    fn decode<'a>(&self, bytes: &'a [u8]) -> Result<Cow<'a, str>, DecodeError> {
+        Ok(self.0.decode_lossy(bytes))
+    }
+
+    fn encode<'a>(&self, s: &'a str) -> Result<Cow<'a, [u8]>, EncodeError> {
+        Ok(self.0.encode_lossy(s, b'?'))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
-use crate::{FieldConversionError, FieldInfo};
+use crate::{CodePageMark, FieldConversionError, FieldInfo};
 use std::string::FromUtf8Error;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Wrapper of `std::io::Error` to forward any reading/writing error
     IoError(std::io::Error),
@@ -27,6 +28,8 @@ pub enum ErrorKind {
     /// The type of the value for the field is not compatible with the
     /// dbase field's type
     IncompatibleType,
+    /// The Code Page is not supported
+    UnsupportedCodePage(CodePageMark),
     /// A string from the database could not be decoded
     StringDecodeError(DecodeError),
     /// A string from the database could not be encoded
@@ -194,6 +197,7 @@ impl std::error::Error for FieldIOError {
             ErrorKind::IncompatibleType => "The types are not compatible",
             ErrorKind::StringDecodeError(_) => "A string from the database could not be decoded",
             ErrorKind::StringEncodeError(_) => "A string from the database could not be encoded",
+            ErrorKind::UnsupportedCodePage(_) => "The code page is not supported",
             ErrorKind::Message(ref msg) => msg,
         }
     }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,8 +1,172 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
+use crate::encoding::DynEncoding;
 use std::io::{Read, Write};
 
 use crate::record::field::{Date, MemoFileType};
+
+// Used this as source: https://blog.codetitans.pl/post/dbf-and-language-code-page/
+// also https://github.com/ethanfurman/dbf/blob/4f8ff35bec18ca167981ba741bfe353f5f362f99/dbf/__init__.py#L8299
+#[derive(Copy, Clone, Debug)]
+pub enum CodePageMark {
+    Undefined,
+    // OEM United States
+    CP437,
+    // OEM Multilingual Latin 1; Western European (DOS
+    CP850,
+    // ANSI Latin 1; Western European (Windows)
+    CP1252,
+    // StandardMacIntosh, // 10000
+    // OEM Latin 2; Central European (DOS)
+    CP852, // 852
+    // OEM Russian; Cyrillic (DOS)
+    CP866,
+    // OEM Nordic; Nordic (DOS)
+    CP865,
+    // OEM Icelandic; Icelandic (DOS)
+    CP861,
+    CP895,
+    CP620,
+    CP737,
+    CP857,
+    CP950,
+    CP949,
+    CP936,
+    CP932,
+    // Thai (Windows)
+    CP874,
+    // ANSI Hebrew; Hebrew (Windows)
+    CP1255,
+    // ANSI Arabic; Arabic (Windows)
+    CP1256, // 1256
+    // RussianMacIntosh, // 10007
+    // MacIntoshEE,      // 10029
+    // GreekMacIntosh,   // 10006
+    // ANSI Central European; Central European (Windows)
+    CP1250,
+    // ANSI Cyrillic; Cyrillic (Windows)
+    CP1251,
+    // ANSI Turkish; Turkish (Windows)
+    CP1254,
+    // ANSI Greek; Greek (Windows)
+    CP1253,
+    Utf8,
+    Invalid,
+}
+
+impl CodePageMark {
+    pub(crate) fn to_encoding(self) -> Option<DynEncoding> {
+        #[cfg(feature = "yore")]
+        {
+            use crate::encoding::{LossyCodePage, Unicode};
+            use yore::code_pages;
+            Some(match self {
+                CodePageMark::CP437 => DynEncoding::new(code_pages::CP437),
+                CodePageMark::CP850 => DynEncoding::new(code_pages::CP850),
+                CodePageMark::CP1252 => DynEncoding::new(code_pages::CP1252),
+                CodePageMark::CP852 => DynEncoding::new(code_pages::CP852),
+                CodePageMark::CP866 => DynEncoding::new(code_pages::CP866),
+                CodePageMark::CP865 => DynEncoding::new(code_pages::CP865),
+                CodePageMark::CP861 => DynEncoding::new(code_pages::CP861),
+                CodePageMark::CP874 => DynEncoding::new(code_pages::CP874),
+                CodePageMark::CP1255 => DynEncoding::new(code_pages::CP1255),
+                CodePageMark::CP1256 => DynEncoding::new(code_pages::CP1256),
+                CodePageMark::CP1250 => DynEncoding::new(code_pages::CP1250),
+                CodePageMark::CP1251 => DynEncoding::new(code_pages::CP1251),
+                CodePageMark::CP1254 => DynEncoding::new(code_pages::CP1254),
+                CodePageMark::CP1253 => DynEncoding::new(code_pages::CP1253),
+                CodePageMark::Utf8 => DynEncoding::new(Unicode),
+                CodePageMark::Undefined | CodePageMark::Invalid => {
+                    DynEncoding::new(LossyCodePage(code_pages::CP1252))
+                }
+                CodePageMark::CP895
+                | CodePageMark::CP620
+                | CodePageMark::CP737
+                | CodePageMark::CP857
+                | CodePageMark::CP950
+                | CodePageMark::CP949
+                | CodePageMark::CP936
+                | CodePageMark::CP932 => {
+                    return None;
+                }
+            })
+        }
+        #[cfg(not(feature = "yore"))]
+        {
+            Some(DynEncoding::new(crate::encoding::UnicodeLossy))
+        }
+    }
+}
+
+impl From<u8> for CodePageMark {
+    fn from(code: u8) -> Self {
+        match code {
+            0x00 => Self::Undefined,
+            0x01 => Self::CP437,
+            0x02 => Self::CP850,
+            0x03 => Self::CP1252,
+            // 0x04 => Self::StandardMacIntosh,
+            0x64 => Self::CP852,
+            0x65 => Self::CP866,
+            0x66 => Self::CP865,
+            0x67 => Self::CP861,
+            0x68 => Self::CP895,
+            0x69 => Self::CP620,
+            0x6A => Self::CP737,
+            0x6B => Self::CP857,
+            0x78 => Self::CP950,
+            0x79 => Self::CP949,
+            0x7A => Self::CP936,
+            0x7B => Self::CP932,
+            0x7C => Self::CP874,
+            0x7D => Self::CP1255,
+            0x7E => Self::CP1256,
+            // 0x96 => Self::RussianMacIntosh,
+            // 0x98 => Self::GreekMacIntosh,
+            0xC8 => Self::CP1250,
+            0xC9 => Self::CP1251,
+            0xCA => Self::CP1254,
+            0xCB => Self::CP1253,
+            0xf0 => Self::Utf8,
+            _ => Self::Invalid,
+        }
+    }
+}
+
+impl From<CodePageMark> for u8 {
+    fn from(code: CodePageMark) -> Self {
+        match code {
+            CodePageMark::Undefined => 0x00,
+            CodePageMark::CP437 => 0x01,
+            CodePageMark::CP850 => 0x02,
+            CodePageMark::CP1252 => 0x03,
+            // CodePageMark::StandardMacIntosh => 0x04,
+            CodePageMark::CP852 => 0x64,
+            CodePageMark::CP866 => 0x65,
+            CodePageMark::CP865 => 0x66,
+            CodePageMark::CP861 => 0x67,
+            CodePageMark::CP895 => 0x68,
+            CodePageMark::CP620 => 0x69,
+            CodePageMark::CP737 => 0x6A,
+            CodePageMark::CP857 => 0x6B,
+            CodePageMark::CP950 => 0x78,
+            CodePageMark::CP949 => 0x79,
+            CodePageMark::CP936 => 0x7A,
+            CodePageMark::CP932 => 0x7B,
+            CodePageMark::CP874 => 0x7C,
+            CodePageMark::CP1255 => 0x7D,
+            CodePageMark::CP1256 => 0x7E,
+            // CodePageMark::RussianMacIntosh => 0x96,
+            // CodePageMark::GreekMacIntosh => 0x98,
+            CodePageMark::CP1250 => 0xC8,
+            CodePageMark::CP1251 => 0xC9,
+            CodePageMark::CP1254 => 0xCA,
+            CodePageMark::CP1253 => 0xCB,
+            CodePageMark::Utf8 => 0xf0,
+            _ => 0,
+        }
+    }
+}
 
 /// Known version of dBase files
 #[derive(Debug, Copy, Clone)]
@@ -135,7 +299,7 @@ pub struct Header {
     pub is_transaction_incomplete: bool,
     pub encryption_flag: u8,
     pub table_flags: TableFlags,
-    pub code_page_mark: u8,
+    pub code_page_mark: CodePageMark,
 }
 
 impl Header {
@@ -154,7 +318,7 @@ impl Header {
             is_transaction_incomplete: false,
             encryption_flag: 0,
             table_flags: TableFlags(0),
-            code_page_mark: 0,
+            code_page_mark: CodePageMark::Undefined,
         }
     }
 
@@ -197,7 +361,7 @@ impl Header {
 
         let table_flags = TableFlags(source.read_u8()?);
 
-        let code_page_mark = source.read_u8()?;
+        let code_page_mark = source.read_u8().map(From::from)?;
 
         let _reserved = source.read_u8()?;
         let _reserved = source.read_u8()?;
@@ -235,7 +399,7 @@ impl Header {
         dest.write_all(&_reserved)?;
 
         dest.write_u8(self.table_flags.0)?;
-        dest.write_u8(self.code_page_mark)?;
+        dest.write_u8(self.code_page_mark.into())?;
         // Reserved
         dest.write_u8(0)?;
         dest.write_u8(0)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,11 +209,11 @@
 //!     age: 32.0,
 //! };
 //!
-//! writer.write_record(&records);
+//! writer.write_record(&records).unwrap();
 //! ```
 //!
 //! If you use the serde optional feature and serde_derive crate you can have the
-//! [WritableRecord](trait.WritableRecord.html) impletemented for you.
+//! [WritableRecord](trait.WritableRecord.html) implemented for you.
 //!
 //! ```
 //! # #[cfg(feature = "serde")]
@@ -275,6 +275,7 @@ mod writing;
 
 pub use crate::encoding::{Encoding, Unicode, UnicodeLossy};
 pub use crate::error::{Error, ErrorKind, FieldIOError};
+pub use crate::header::CodePageMark;
 pub use crate::reading::{
     read, FieldIterator, NamedValue, ReadableRecord, Reader, Record, RecordIterator, TableInfo,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,9 @@
 //! }
 //!
 //! impl dbase::ReadableRecord for StationRecord {
-//!     fn read_using<T, E>(field_iterator: &mut dbase::FieldIterator<T, E>) -> Result<Self, dbase::FieldIOError>
-//!          where T: Read + Seek,
-//!                 E: Encoding {
+//!     fn read_using<T>(field_iterator: &mut dbase::FieldIterator<T>) -> Result<Self, dbase::FieldIOError>
+//!          where T: Read + Seek
+//!    {
 //!         use dbase::Encoding;Ok(Self {
 //!             name: field_iterator.read_next_field_as()?.value,
 //!             marker_col: field_iterator.read_next_field_as()?.value,
@@ -189,9 +189,9 @@
 //! }
 //!
 //! impl WritableRecord for User {
-//!     fn write_using<'a, W, E>(&self, field_writer: &mut FieldWriter<'a, W, E>) -> Result<(), FieldIOError>
-//!         where W: Write,
-//!               E: Encoding, {
+//!     fn write_using<'a, W>(&self, field_writer: &mut FieldWriter<'a, W>) -> Result<(), FieldIOError>
+//!         where W: Write
+//!     {
 //!         field_writer.write_next_field_value(&self.nick_name)?;
 //!         field_writer.write_next_field_value(&self.age)?;
 //!         Ok(())
@@ -315,8 +315,8 @@ macro_rules! dbase_record {
         }
 
         impl dbase::ReadableRecord for $name {
-            fn read_using<T, E>(field_iterator: &mut dbase::FieldIterator<T, E>) -> Result<Self, dbase::FieldIOError>
-                where T: std::io::Read + std::io::Seek, E: $crate::Encoding
+            fn read_using<T>(field_iterator: &mut dbase::FieldIterator<T>) -> Result<Self, dbase::FieldIOError>
+                where T: std::io::Read + std::io::Seek
                 {
                     Ok(Self {
                         $(
@@ -329,9 +329,9 @@ macro_rules! dbase_record {
         }
 
        impl dbase::WritableRecord for $name {
-           fn write_using<'a, W, E>(&self, field_writer: &mut dbase::FieldWriter<'a, W, E>) -> Result<(), dbase::FieldIOError>
+           fn write_using<'a, W>(&self, field_writer: &mut dbase::FieldWriter<'a, W>) -> Result<(), dbase::FieldIOError>
            where W: std::io::Write,
-                 E: $crate::Encoding{
+           {
                 $(
                     field_writer.write_next_field_value(&self.$field_name)?;
                 )+

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -3,22 +3,22 @@ use std::io::Write;
 
 use crate::record::field::FieldType;
 use crate::writing::FieldWriter;
-use crate::{Date, Encoding, FieldIOError};
+use crate::{Date, FieldIOError};
 use crate::{ErrorKind, WritableRecord};
 
 impl<T> WritableRecord for T
 where
     T: Serialize,
 {
-    fn write_using<'a, W: Write, E: Encoding>(
+    fn write_using<'a, W: Write>(
         &self,
-        field_writer: &mut FieldWriter<'a, W, E>,
+        field_writer: &mut FieldWriter<'a, W>,
     ) -> Result<(), FieldIOError> {
         self.serialize(field_writer)
     }
 }
 
-impl<'a, W: Write, E: Encoding> Serializer for &mut FieldWriter<'a, W, E> {
+impl<'a, W: Write> Serializer for &mut FieldWriter<'a, W> {
     type Ok = ();
     type Error = FieldIOError;
     type SerializeSeq = Self;
@@ -212,7 +212,7 @@ impl<'a, W: Write, E: Encoding> Serializer for &mut FieldWriter<'a, W, E> {
     }
 }
 
-impl<'a, W: Write, E: Encoding> serde::ser::SerializeStructVariant for &mut FieldWriter<'a, W, E> {
+impl<'a, W: Write> serde::ser::SerializeStructVariant for &mut FieldWriter<'a, W> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -232,7 +232,7 @@ impl<'a, W: Write, E: Encoding> serde::ser::SerializeStructVariant for &mut Fiel
     }
 }
 
-impl<'a, W: Write, E: Encoding> serde::ser::SerializeStruct for &mut FieldWriter<'a, W, E> {
+impl<'a, W: Write> serde::ser::SerializeStruct for &mut FieldWriter<'a, W> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -252,7 +252,7 @@ impl<'a, W: Write, E: Encoding> serde::ser::SerializeStruct for &mut FieldWriter
     }
 }
 
-impl<'a, W: Write, E: Encoding> serde::ser::SerializeSeq for &mut FieldWriter<'a, W, E> {
+impl<'a, W: Write> serde::ser::SerializeSeq for &mut FieldWriter<'a, W> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -268,7 +268,7 @@ impl<'a, W: Write, E: Encoding> serde::ser::SerializeSeq for &mut FieldWriter<'a
     }
 }
 
-impl<'a, W: Write, E: Encoding> serde::ser::SerializeMap for &mut FieldWriter<'a, W, E> {
+impl<'a, W: Write> serde::ser::SerializeMap for &mut FieldWriter<'a, W> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -291,7 +291,7 @@ impl<'a, W: Write, E: Encoding> serde::ser::SerializeMap for &mut FieldWriter<'a
     }
 }
 
-impl<'a, W: Write, E: Encoding> serde::ser::SerializeTupleVariant for &mut FieldWriter<'a, W, E> {
+impl<'a, W: Write> serde::ser::SerializeTupleVariant for &mut FieldWriter<'a, W> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -307,7 +307,7 @@ impl<'a, W: Write, E: Encoding> serde::ser::SerializeTupleVariant for &mut Field
     }
 }
 
-impl<'a, W: Write, E: Encoding> serde::ser::SerializeTupleStruct for &mut FieldWriter<'a, W, E> {
+impl<'a, W: Write> serde::ser::SerializeTupleStruct for &mut FieldWriter<'a, W> {
     type Ok = ();
     type Error = FieldIOError;
 
@@ -323,7 +323,7 @@ impl<'a, W: Write, E: Encoding> serde::ser::SerializeTupleStruct for &mut FieldW
     }
 }
 
-impl<'a, W: Write, E: Encoding> serde::ser::SerializeTuple for &mut FieldWriter<'a, W, E> {
+impl<'a, W: Write> serde::ser::SerializeTuple for &mut FieldWriter<'a, W> {
     type Ok = ();
     type Error = FieldIOError;
 

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use byteorder::WriteBytesExt;
 
-use crate::encoding::DynEncoding;
+use crate::encoding::{AsCodePageMark, DynEncoding};
 use crate::header::Header;
 use crate::reading::TERMINATOR_VALUE;
 use crate::reading::{TableInfo, BACKLINK_SIZE};
@@ -585,6 +585,7 @@ impl<W: Write + Seek> TableWriter<W> {
 
         self.header.offset_to_first_record = offset_to_first_record as u16;
         self.header.size_of_record = size_of_record;
+        self.header.code_page_mark = self.encoding.code_page_mark();
     }
 
     fn write_header(&mut self) -> Result<(), Error> {

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -9,15 +9,12 @@ mod serde_tests {
 
     use serde_derive::{Deserialize, Serialize};
 
-    use dbase::{
-        Encoding, ErrorKind, FieldName, ReadableRecord, Reader, TableWriterBuilder, WritableRecord,
-    };
+    use dbase::{ErrorKind, FieldName, ReadableRecord, Reader, TableWriterBuilder, WritableRecord};
     use std::fmt::Debug;
 
-    fn write_read_compare<R, E>(records: &Vec<R>, writer_builder: TableWriterBuilder<E>)
+    fn write_read_compare<R>(records: &Vec<R>, writer_builder: TableWriterBuilder)
     where
         R: WritableRecord + ReadableRecord + Debug + PartialEq,
-        E: Encoding,
     {
         let mut dst = Cursor::new(Vec::<u8>::new());
         let writer = writer_builder.build_with_dest(&mut dst);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,7 @@ extern crate dbase;
 use std::io::{Cursor, Read, Seek, Write};
 
 use dbase::{
-    Date, DateTime, Encoding, FieldIOError, FieldIterator, FieldName, FieldValue, FieldWriter,
+    Date, DateTime, FieldIOError, FieldIterator, FieldName, FieldValue, FieldWriter,
     ReadableRecord, Reader, Record, TableWriterBuilder, Time, WritableRecord,
 };
 use std::convert::{TryFrom, TryInto};
@@ -16,10 +16,9 @@ const NULL_PADDED_NUMERIC_DBF: &str = "./tests/data/contain_null_padded_numeric.
 #[cfg(feature = "yore")]
 const CP850_DBF: &str = "tests/data/cp850.dbf";
 
-fn write_read_compare<R, E>(records: &Vec<R>, writer_builder: TableWriterBuilder<E>)
+fn write_read_compare<R>(records: &Vec<R>, writer_builder: TableWriterBuilder)
 where
     R: WritableRecord + ReadableRecord + Debug + PartialEq,
-    E: Encoding,
 {
     let mut dst = Cursor::new(Vec::<u8>::new());
     let writer = writer_builder.build_with_dest(&mut dst);
@@ -107,10 +106,9 @@ struct Album {
 }
 
 impl ReadableRecord for Album {
-    fn read_using<T, E>(field_iterator: &mut FieldIterator<T, E>) -> Result<Self, FieldIOError>
+    fn read_using<T>(field_iterator: &mut FieldIterator<T>) -> Result<Self, FieldIOError>
     where
         T: Read + Seek,
-        E: Encoding,
     {
         Ok(Self {
             artist: field_iterator.read_next_field_as()?.value,
@@ -123,9 +121,9 @@ impl ReadableRecord for Album {
 }
 
 impl WritableRecord for Album {
-    fn write_using<'a, W: Write, E: Encoding>(
+    fn write_using<'a, W: Write>(
         &self,
-        field_writer: &mut FieldWriter<'a, W, E>,
+        field_writer: &mut FieldWriter<'a, W>,
     ) -> Result<(), FieldIOError> {
         field_writer.write_next_field_value(&self.artist)?;
         field_writer.write_next_field_value(&self.name)?;


### PR DESCRIPTION
This removes the encoding from the type parameters.

The encoding is used inernally as a `Box<dyn Encoding>`, allowing to keep the current API, and avoiding to
complexify it.

It also allows to use the code page mark written in the header to auto select the encoding after the file is opened.