### PR TITLE
Make 'Date's const-constructable

### DIFF
--- a/src/record/field.rs
+++ b/src/record/field.rs
@@ -402,7 +402,7 @@ impl Date {
     ///
     /// panics if the year has more than 4 digits or if the day is greater than 31 or
     /// the month greater than 12
-    pub fn new(day: u32, month: u32, year: u32) -> Self {
+    pub const fn new(day: u32, month: u32, year: u32) -> Self {
         if year > 9999 {
             panic!("Year cannot have more than 4 digits")
         }


### PR DESCRIPTION
This small change makes `Date`s `new` function be callable in `const` contexts. This is useful when writing tests or in other contexts where record data may be statically created.