### PR TITLE
add first iteration of dbase::File

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ yore = {version = "0.3.3", optional = true}
 
 [dev-dependencies]
 serde_derive = "1.0.102"
-
+tempfile = "3.4.0"

--- a/examples/file.rs
+++ b/examples/file.rs
@@ -1,0 +1,34 @@
+use dbase::FieldValue;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let from = "./tests/data/stations.dbf";
+    let to = "./stations-can-be-deleted.dbf";
+    std::fs::copy(from, to)?;
+
+    let mut file = dbase::File::open_read_write(to)?;
+
+    println!("{:?}", file.fields());
+
+    let name_field = file.field_index("name").unwrap();
+
+    let mut r = file.record(0).unwrap();
+    let mut field = r.field(name_field).unwrap();
+
+    let field_value = field.read().unwrap();
+    println!("value: {}", field_value);
+
+    field.write(&FieldValue::Character(Option::from("Toulouse".to_string())))?;
+
+    let rr = file.record(0).unwrap().read().unwrap();
+    println!("record: {:?}", rr);
+
+    let mut record_iter = file.records();
+    while let Some(mut record_ref) = record_iter.next() {
+        println!("record: {:?}", record_ref);
+        println!("{:#?}", record_ref.read().unwrap())
+    }
+
+    std::fs::remove_file(to)?;
+
+    Ok(())
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -8,7 +8,11 @@ use crate::{
     ErrorKind, FieldConversionError, FieldIOError, FieldIterator, FieldValue, ReadableRecord,
 };
 
-impl<'de, 'a, 'f, R: Read + Seek> SeqAccess<'de> for &mut FieldIterator<'a, R> {
+impl<'de, 'a, 'f, R1, R2> SeqAccess<'de> for &mut FieldIterator<'a, R1, R2>
+where
+    R1: Read + Seek,
+    R2: Read + Seek,
+{
     type Error = FieldIOError;
 
     fn next_element_seed<T>(
@@ -27,7 +31,11 @@ impl<'de, 'a, 'f, R: Read + Seek> SeqAccess<'de> for &mut FieldIterator<'a, R> {
 }
 
 //TODO maybe we can deserialize numbers other than f32 & f64 by converting using TryFrom
-impl<'de, 'a, 'f, T: Read + Seek> Deserializer<'de> for &mut FieldIterator<'a, T> {
+impl<'de, 'a, 'f, T, R> Deserializer<'de> for &mut FieldIterator<'a, T, R>
+where
+    T: Read + Seek,
+    R: Read + Seek,
+{
     type Error = FieldIOError;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
@@ -324,9 +332,10 @@ impl<'de, 'a, 'f, T: Read + Seek> Deserializer<'de> for &mut FieldIterator<'a, T
 }
 
 impl<S: DeserializeOwned> ReadableRecord for S {
-    fn read_using<T>(field_iterator: &mut FieldIterator<T>) -> Result<Self, FieldIOError>
+    fn read_using<T, R>(field_iterator: &mut FieldIterator<T, R>) -> Result<Self, FieldIOError>
     where
         T: Read + Seek,
+        R: Read + Seek,
     {
         S::deserialize(field_iterator)
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,435 @@
+use crate::encoding::DynEncoding;
+use crate::header::Header;
+use crate::reading::{BACKLINK_SIZE, TERMINATOR_VALUE};
+use crate::writing::WritableAsDbaseField;
+use crate::ErrorKind::UnsupportedCodePage;
+use crate::{
+    Error, ErrorKind, FieldConversionError, FieldIOError, FieldInfo, FieldIterator, FieldValue,
+    FieldWriter, ReadableRecord, WritableRecord,
+};
+use byteorder::ReadBytesExt;
+use std::fmt::{Debug, Formatter};
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
+pub struct FieldIndex(pub usize);
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
+pub struct RecordIndex(pub usize);
+
+pub struct FieldRef<'a, T> {
+    file: &'a mut File<T>,
+    record_index: RecordIndex,
+    field_index: FieldIndex,
+}
+
+impl<'a, T> Debug for FieldRef<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FieldRef")
+            .field("record_index", &self.record_index)
+            .field("field_index", &self.field_index)
+            .finish()
+    }
+}
+
+impl<'a, T> FieldRef<'a, T> {
+    fn position_in_source(&self) -> u64 {
+        let record_position = self
+            .file
+            .header
+            .record_position(self.record_index.0)
+            .unwrap() as u64;
+        let position_in_record = self.file.fields_info[..self.field_index.0]
+            .iter()
+            .map(|i| i.field_length as u64)
+            .sum::<u64>();
+
+        record_position + position_in_record
+    }
+}
+
+impl<'a, T> FieldRef<'a, T>
+where
+    T: Seek,
+{
+    pub fn seek_to_beginning(&mut self) -> Result<u64, FieldIOError> {
+        let field_info = &self.file.fields_info[self.field_index.0];
+
+        self.file
+            .inner
+            .seek(SeekFrom::Start(self.position_in_source()))
+            .map_err(|e| FieldIOError::new(ErrorKind::IoError(e), Some(field_info.clone())))
+    }
+}
+
+impl<'a, T> FieldRef<'a, T>
+where
+    T: Seek + Read,
+{
+    pub fn read(&mut self) -> Result<FieldValue, FieldIOError> {
+        self.seek_to_beginning()?;
+
+        let field_info = &self.file.fields_info[self.field_index.0];
+
+        let buffer = &mut self.file.field_data_buffer[..field_info.field_length as usize];
+        self.file
+            .inner
+            .read(buffer)
+            .map_err(|e| FieldIOError::new(ErrorKind::IoError(e), Some(field_info.clone())))?;
+
+        FieldValue::read_from::<Cursor<Vec<u8>>, _>(
+            &buffer,
+            &mut None,
+            field_info,
+            &self.file.encoding,
+        )
+        .map_err(|e| FieldIOError::new(e, Some(field_info.clone())))
+    }
+
+    pub fn read_as<ValueType>(&mut self) -> Result<ValueType, FieldIOError>
+    where
+        ValueType: TryFrom<FieldValue, Error = FieldConversionError>,
+    {
+        let value = self.read()?;
+
+        let converted_value = ValueType::try_from(value)?;
+
+        Ok(converted_value)
+    }
+}
+
+impl<'a, T> FieldRef<'a, T>
+where
+    T: Seek + Write,
+{
+    pub fn write<ValueType>(&mut self, value: &ValueType) -> Result<(), FieldIOError>
+    where
+        ValueType: WritableAsDbaseField,
+    {
+        self.seek_to_beginning()?;
+
+        let field_info = &self.file.fields_info[self.field_index.0];
+
+        let buffer = &mut self.file.field_data_buffer[..field_info.field_length as usize];
+        buffer.fill(0);
+        let mut cursor = Cursor::new(buffer);
+        value
+            .write_as(field_info, &self.file.encoding, &mut cursor)
+            .map_err(|e| FieldIOError::new(e, Some(field_info.clone())))?;
+
+        let buffer = cursor.into_inner();
+        self.file
+            .inner
+            .write_all(&buffer)
+            .map_err(|e| FieldIOError::new(ErrorKind::IoError(e), Some(field_info.clone())))?;
+
+        Ok(())
+    }
+}
+
+pub struct RecordRef<'a, T> {
+    file: &'a mut File<T>,
+    index: RecordIndex,
+}
+
+impl<'a, T> Debug for RecordRef<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecordRef")
+            .field("index", &self.index)
+            .finish()
+    }
+}
+
+impl<'a, T> RecordRef<'a, T> {
+    pub fn field<'b>(&'b mut self, index: FieldIndex) -> Option<FieldRef<'b, T>> {
+        if index.0 >= self.file.fields_info.len() {
+            return None;
+        }
+        Some(FieldRef {
+            file: self.file,
+            record_index: self.index,
+            field_index: index,
+        })
+    }
+
+    fn position_in_source(&self) -> u64 {
+        self.file.header.record_position(self.index.0).unwrap() as u64
+    }
+}
+
+impl<'a, T> RecordRef<'a, T>
+where
+    T: Seek,
+{
+    pub fn seek_to_beginning(&mut self) -> Result<u64, FieldIOError> {
+        self.file
+            .inner
+            .seek(SeekFrom::Start(self.position_in_source()))
+            .map_err(|e| FieldIOError::new(ErrorKind::IoError(e), None))
+    }
+}
+
+impl<'a, T> RecordRef<'a, T>
+where
+    T: Read + Seek,
+{
+    pub fn read(&mut self) -> Result<crate::Record, FieldIOError> {
+        self.read_as()
+    }
+
+    pub fn read_as<R>(&mut self) -> Result<R, FieldIOError>
+    where
+        R: ReadableRecord,
+    {
+        self.seek_to_beginning()?;
+
+        let mut field_iterator = FieldIterator::<_, Cursor<Vec<u8>>> {
+            source: &mut self.file.inner,
+            fields_info: self.file.fields_info.iter().peekable(),
+            memo_reader: &mut None,
+            field_data_buffer: &mut self.file.field_data_buffer,
+            encoding: &self.file.encoding,
+        };
+        R::read_using(&mut field_iterator)
+    }
+}
+
+impl<'a, T> RecordRef<'a, T>
+where
+    T: Write + Seek,
+{
+    pub fn write<R>(&mut self, record: &R) -> Result<(), FieldIOError>
+    where
+        R: WritableRecord,
+    {
+        self.seek_to_beginning()?;
+
+        let mut field_writer = FieldWriter {
+            dst: &mut self.file.inner,
+            fields_info: self.file.fields_info.iter().peekable(),
+            field_buffer: &mut Cursor::new(&mut self.file.field_data_buffer),
+            encoding: &self.file.encoding,
+        };
+
+        field_writer
+            .write_deletion_flag()
+            .map_err(|error| FieldIOError::new(ErrorKind::IoError(error), None))?;
+
+        record.write_using(&mut field_writer)
+    }
+}
+
+pub struct FileRecordIterator<'a, T> {
+    file: &'a mut File<T>,
+    current_record: RecordIndex,
+}
+
+impl<'a, T> FileRecordIterator<'a, T> {
+    // To implement iterator we need the Iterator trait to make use of GATs
+    // which is not the case, to iteration will have to use the while let Some() pattern
+    pub fn next<'s>(&'s mut self) -> Option<RecordRef<'s, T>> {
+        if self.current_record.0 >= self.file.header.num_records as usize {
+            None
+        } else {
+            let r = RecordRef {
+                file: &mut self.file,
+                index: self.current_record,
+            };
+            self.current_record.0 += 1;
+            Some(r)
+        }
+    }
+}
+
+pub struct File<T> {
+    pub(crate) inner: T,
+    pub(crate) header: Header,
+    pub(crate) fields_info: Vec<FieldInfo>,
+    pub(crate) encoding: DynEncoding,
+    /// Non-Memo field length is stored on a u8,
+    /// so fields cannot exceed 255 bytes
+    field_data_buffer: [u8; 255],
+}
+
+impl<T> File<T> {
+    pub fn fields(&self) -> &[FieldInfo] {
+        self.fields_info.as_slice()
+    }
+
+    pub fn field_index(&self, name: &str) -> Option<FieldIndex> {
+        self.fields_info
+            .iter()
+            .position(|info| info.name == name)
+            .map(FieldIndex)
+    }
+
+    pub fn num_records(&self) -> usize {
+        self.header.num_records as usize
+    }
+}
+
+impl<T: Read + Seek> File<T> {
+    pub fn new(mut source: T) -> Result<Self, Error> {
+        let header = Header::read_from(&mut source).map_err(|error| Error::io_error(error, 0))?;
+
+        let offset = if header.file_type.is_visual_fox_pro() {
+            if BACKLINK_SIZE > header.offset_to_first_record {
+                panic!("Invalid file");
+            }
+            header.offset_to_first_record - BACKLINK_SIZE
+        } else {
+            header.offset_to_first_record
+        };
+        let num_fields =
+            (offset as usize - Header::SIZE - std::mem::size_of::<u8>()) / FieldInfo::SIZE;
+
+        let mut fields_info = Vec::<FieldInfo>::with_capacity(num_fields as usize + 1);
+        fields_info.push(FieldInfo::new_deletion_flag());
+        for _ in 0..num_fields {
+            let info = FieldInfo::read_from(&mut source).map_err(|error| Error {
+                record_num: 0,
+                field: None,
+                kind: error,
+            })?;
+            fields_info.push(info);
+        }
+
+        let terminator = source
+            .read_u8()
+            .map_err(|error| Error::io_error(error, 0))?;
+
+        debug_assert_eq!(terminator, TERMINATOR_VALUE);
+
+        source
+            .seek(SeekFrom::Start(u64::from(header.offset_to_first_record)))
+            .map_err(|error| Error::io_error(error, 0))?;
+
+        let encoding = header.code_page_mark.to_encoding().ok_or_else(|| {
+            let field_error = FieldIOError::new(UnsupportedCodePage(header.code_page_mark), None);
+            Error::new(field_error, 0)
+        })?;
+        Ok(Self {
+            inner: source,
+            // memo_reader: None,
+            header,
+            fields_info,
+            encoding,
+            field_data_buffer: [0u8; 255],
+        })
+    }
+
+    pub fn record(&mut self, index: usize) -> Option<RecordRef<'_, T>> {
+        if index >= self.header.num_records as usize {
+            None
+        } else {
+            Some(RecordRef {
+                file: self,
+                index: RecordIndex(index),
+            })
+        }
+    }
+
+    pub fn records(&mut self) -> FileRecordIterator<'_, T> {
+        FileRecordIterator {
+            file: self,
+            current_record: RecordIndex(0),
+        }
+    }
+}
+
+impl<T: Write + Seek> File<T> {
+    pub fn append_record<R>(&mut self, record: &R) -> Result<(), FieldIOError>
+    where
+        R: WritableRecord,
+    {
+        self.append_records(std::slice::from_ref(record))
+    }
+
+    pub fn append_records<R>(&mut self, records: &[R]) -> Result<(), FieldIOError>
+    where
+        R: WritableRecord,
+    {
+        let end_of_last_record = self.header.offset_to_first_record as u64
+            + self.num_records() as u64 * self.header.size_of_record as u64;
+        self.inner
+            .seek(SeekFrom::Start(end_of_last_record))
+            .map_err(|error| FieldIOError::new(ErrorKind::IoError(error), None))?;
+
+        for record in records {
+            let mut field_writer = FieldWriter {
+                dst: &mut self.inner,
+                fields_info: self.fields_info.iter().peekable(),
+                field_buffer: &mut Cursor::new(&mut self.field_data_buffer),
+                encoding: &self.encoding,
+            };
+
+            field_writer
+                .write_deletion_flag()
+                .map_err(|error| FieldIOError::new(ErrorKind::IoError(error), None))?;
+
+            record.write_using(&mut field_writer)?;
+
+            self.header.num_records = self.header.num_records.checked_add(1).unwrap();
+        }
+
+        self.sync_all()
+            .map_err(|error| FieldIOError::new(ErrorKind::IoError(error), None))?;
+
+        Ok(())
+    }
+
+    pub fn sync_all(&mut self) -> std::io::Result<()> {
+        let current_pos = self.inner.seek(SeekFrom::Current(0))?;
+        self.inner.seek(SeekFrom::Start(0))?;
+        self.header.write_to(&mut self.inner)?;
+        self.inner.seek(SeekFrom::Start(current_pos))?;
+        Ok(())
+    }
+}
+
+impl File<std::fs::File> {
+    pub fn open_with_options<P: AsRef<Path>>(
+        path: P,
+        options: std::fs::OpenOptions,
+    ) -> Result<Self, Error> {
+        let file = options
+            .open(path)
+            .map_err(|error| Error::io_error(error, 0))?;
+        File::new(file)
+    }
+
+    /// Opens an existing dBase file in read only mode
+    pub fn open_read_only<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let file = std::fs::File::open(path).map_err(|error| Error::io_error(error, 0))?;
+
+        File::new(file)
+    }
+
+    /// Opens an existing dBase file in write only mode
+    pub fn open_write_only<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let mut options = std::fs::OpenOptions::new();
+        options
+            .read(false)
+            .write(true)
+            .create(false)
+            .truncate(false);
+
+        File::open_with_options(path, options)
+    }
+
+    /// Opens an existing dBase file in read **and** write mode
+    pub fn open_read_write<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).write(true).create(false).truncate(false);
+
+        File::open_with_options(path, options)
+    }
+
+    /// This function will create a file if it does not exist, and will truncate it if it does.
+    pub fn create<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let file = std::fs::File::create(path).map_err(|error| Error::io_error(error, 0))?;
+
+        File::new(file)
+    }
+}

--- a/src/header.rs
+++ b/src/header.rs
@@ -405,6 +405,16 @@ impl Header {
         dest.write_u8(0)?;
         Ok(())
     }
+
+    pub(crate) fn record_position(&self, index: usize) -> Option<usize> {
+        if index >= self.num_records as usize {
+            None
+        } else {
+            let offset =
+                self.offset_to_first_record as usize + (index * self.size_of_record as usize);
+            Some(offset)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,15 +63,17 @@
 //! }
 //!
 //! impl dbase::ReadableRecord for StationRecord {
-//!     fn read_using<T>(field_iterator: &mut dbase::FieldIterator<T>) -> Result<Self, dbase::FieldIOError>
-//!          where T: Read + Seek
+//!     fn read_using<R1, R2>(field_iterator: &mut dbase::FieldIterator<R1, R2>) -> Result<Self, dbase::FieldIOError>
+//!          where R1: Read + Seek,
+//!                R2: Read + Seek,
 //!    {
-//!         use dbase::Encoding;Ok(Self {
-//!             name: field_iterator.read_next_field_as()?.value,
-//!             marker_col: field_iterator.read_next_field_as()?.value,
-//!             marker_sym: field_iterator.read_next_field_as()?.value,
-//!             line: field_iterator.read_next_field_as()?.value,
-//!         })
+//!        use dbase::Encoding;
+//!        Ok(Self {
+//!            name: field_iterator.read_next_field_as()?.value,
+//!            marker_col: field_iterator.read_next_field_as()?.value,
+//!            marker_sym: field_iterator.read_next_field_as()?.value,
+//!            line: field_iterator.read_next_field_as()?.value,
+//!        })
 //!     }
 //! }
 //! # fn main() -> Result<(), dbase::Error> {
@@ -268,10 +270,13 @@ pub use yore;
 
 pub mod encoding;
 mod error;
+mod file;
 mod header;
 mod reading;
 mod record;
 mod writing;
+
+pub use file::{FieldRef, File, RecordRef};
 
 pub use crate::encoding::{Encoding, Unicode, UnicodeLossy};
 pub use crate::error::{Error, ErrorKind, FieldIOError};
@@ -316,8 +321,9 @@ macro_rules! dbase_record {
         }
 
         impl dbase::ReadableRecord for $name {
-            fn read_using<T>(field_iterator: &mut dbase::FieldIterator<T>) -> Result<Self, dbase::FieldIOError>
-                where T: std::io::Read + std::io::Seek
+            fn read_using<Source, MemoSource>(field_iterator: &mut dbase::FieldIterator<Source, MemoSource>) -> Result<Self, dbase::FieldIOError>
+                where Source: std::io::Read + std::io::Seek,
+                      MemoSource: std::io::Read + std::io::Seek
                 {
                     Ok(Self {
                         $(

--- a/tests/test_file.rs
+++ b/tests/test_file.rs
@@ -1,0 +1,241 @@
+use std::io::{Read, Seek, SeekFrom, Write};
+
+fn copy_to_tmp_file(origin: &str) -> std::io::Result<std::fs::File> {
+    let mut data = vec![];
+    std::fs::File::open(origin).and_then(|mut f| f.read_to_end(&mut data))?;
+
+    let mut tmp_file = tempfile::tempfile()?;
+    tmp_file.write_all(&data)?;
+    tmp_file.flush()?;
+    tmp_file.seek(SeekFrom::Start(0))?;
+
+    Ok(tmp_file)
+}
+
+fn copy_to_named_tmp_file(origin: &str) -> std::io::Result<tempfile::NamedTempFile> {
+    let mut data = vec![];
+    std::fs::File::open(origin).and_then(|mut f| f.read_to_end(&mut data))?;
+
+    let mut tmp_file = tempfile::NamedTempFile::new()?;
+    tmp_file.write_all(&data)?;
+    tmp_file.flush()?;
+    tmp_file.seek(SeekFrom::Start(0))?;
+
+    Ok(tmp_file)
+}
+
+#[test]
+fn test_file_read_only() -> Result<(), Box<dyn std::error::Error>> {
+    let mut file = dbase::File::open_read_only("tests/data/stations.dbf")?;
+
+    assert_eq!(file.num_records(), 6);
+
+    let name_idx = file.field_index("name").unwrap();
+    let marker_color_idx = file.field_index("marker-col").unwrap();
+    let marker_symbol_idx = file.field_index("marker-sym").unwrap();
+
+    // Test manually reading fields (not in correct order) to FieldValue
+    let mut rh = file.record(3).unwrap();
+    let marker_color = rh.field(marker_color_idx).unwrap().read()?;
+    assert_eq!(
+        marker_color,
+        dbase::FieldValue::Character(Some("#ff0000".to_string()))
+    );
+    let name = rh.field(name_idx).unwrap().read()?;
+    assert_eq!(
+        name,
+        dbase::FieldValue::Character(Some("Judiciary Sq".to_string()))
+    );
+    let marker_symbol = rh.field(marker_symbol_idx).unwrap().read()?;
+    assert_eq!(
+        marker_symbol,
+        dbase::FieldValue::Character(Some("rail-metro".to_string()))
+    );
+
+    // Test manually reading fields (not in correct order) to concrete type
+    let mut rh = file.record(0).unwrap();
+    let marker_color = rh.field(marker_color_idx).unwrap().read_as::<String>()?;
+    assert_eq!(marker_color, "#0000ff");
+    let name = rh.field(name_idx).unwrap().read_as::<String>()?;
+    assert_eq!(name, "Van Dorn Street");
+    let marker_symbol = rh.field(marker_symbol_idx).unwrap().read_as::<String>()?;
+    assert_eq!(marker_symbol, "rail-metro");
+
+    // Test whole record at once
+    let mut rh = file.record(5).unwrap();
+    let record = rh.read()?;
+    let mut expected_record = dbase::Record::default();
+    expected_record.insert(
+        "name".to_string(),
+        dbase::FieldValue::Character(Some("Metro Center".to_string())),
+    );
+    expected_record.insert(
+        "marker-col".to_string(),
+        dbase::FieldValue::Character(Some("#ff0000".to_string())),
+    );
+    expected_record.insert(
+        "marker-sym".to_string(),
+        dbase::FieldValue::Character(Some("rail-metro".to_string())),
+    );
+    expected_record.insert(
+        "line".to_string(),
+        dbase::FieldValue::Character(Some("red".to_string())),
+    );
+
+    assert_eq!(record, expected_record);
+
+    Ok(())
+}
+
+#[test]
+fn test_file_read_write() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_file = copy_to_tmp_file("tests/data/stations.dbf")?;
+    let mut file = dbase::File::new(tmp_file)?;
+
+    assert_eq!(file.num_records(), 6);
+
+    let name_idx = file.field_index("name").unwrap();
+    let marker_color_idx = file.field_index("marker-col").unwrap();
+    let marker_symbol_idx = file.field_index("marker-sym").unwrap();
+
+    // Test manually writing fields (not in correct order) to FieldValue
+    let mut rh = file.record(3).unwrap();
+
+    let mut fh = rh.field(marker_color_idx).unwrap();
+    let marker_color = fh.read()?;
+    assert_eq!(
+        marker_color,
+        dbase::FieldValue::Character(Some("#ff0000".to_string()))
+    );
+
+    fh.write(&dbase::FieldValue::Character(Some("#00ff00".to_string())))?;
+    let marker_color = fh.read()?;
+    assert_eq!(
+        marker_color,
+        dbase::FieldValue::Character(Some("#00ff00".to_string()))
+    );
+
+    let mut fh = rh.field(name_idx).unwrap();
+    let name = fh.read()?;
+    assert_eq!(
+        name,
+        dbase::FieldValue::Character(Some("Judiciary Sq".to_string()))
+    );
+    fh.write(&dbase::FieldValue::Character(Some("Paris".to_string())))?;
+    let marker_color = fh.read()?;
+    assert_eq!(
+        marker_color,
+        dbase::FieldValue::Character(Some("Paris".to_string()))
+    );
+
+    let mut fh = rh.field(marker_symbol_idx).unwrap();
+    let marker_symbol = fh.read()?;
+    assert_eq!(
+        marker_symbol,
+        dbase::FieldValue::Character(Some("rail-metro".to_string()))
+    );
+    fh.write(&dbase::FieldValue::Character(Some("road".to_string())))?;
+    let marker_color = fh.read()?;
+    assert_eq!(
+        marker_color,
+        dbase::FieldValue::Character(Some("road".to_string()))
+    );
+
+    // Test manually writing fields (not in correct order) to concrete type
+    let mut rh = file.record(0).unwrap();
+    let marker_color = rh.field(marker_color_idx).unwrap().read_as::<String>()?;
+    assert_eq!(marker_color, "#0000ff");
+    rh.field(marker_color_idx).unwrap().write(&"#ff00ff")?;
+    let marker_color = rh.field(marker_color_idx).unwrap().read_as::<String>()?;
+    assert_eq!(marker_color, "#ff00ff");
+
+    let name = rh.field(name_idx).unwrap().read_as::<String>()?;
+    assert_eq!(name, "Van Dorn Street");
+    rh.field(name_idx).unwrap().write(&"Yoshi's street")?;
+    let name = rh.field(name_idx).unwrap().read_as::<String>()?;
+    assert_eq!(name, "Yoshi's street");
+
+    let marker_symbol = rh.field(marker_symbol_idx).unwrap().read_as::<String>()?;
+    assert_eq!(marker_symbol, "rail-metro");
+    rh.field(marker_symbol_idx).unwrap().write(&"egg")?;
+    let marker_symbol = rh.field(marker_symbol_idx).unwrap().read_as::<String>()?;
+    assert_eq!(marker_symbol, "egg");
+
+    // Test whole record at once
+    let mut rh = file.record(5).unwrap();
+    let record = rh.read()?;
+    let mut expected_record = dbase::Record::default();
+    expected_record.insert(
+        "name".to_string(),
+        dbase::FieldValue::Character(Some("Metro Center".to_string())),
+    );
+    expected_record.insert(
+        "marker-col".to_string(),
+        dbase::FieldValue::Character(Some("#ff0000".to_string())),
+    );
+    expected_record.insert(
+        "marker-sym".to_string(),
+        dbase::FieldValue::Character(Some("rail-metro".to_string())),
+    );
+    expected_record.insert(
+        "line".to_string(),
+        dbase::FieldValue::Character(Some("red".to_string())),
+    );
+
+    assert_eq!(record, expected_record);
+
+    let old = expected_record.insert(
+        "name".to_string(),
+        dbase::FieldValue::Character(Some("Nook Island".to_string())),
+    );
+    assert!(old.is_some());
+    rh.write(&expected_record)?;
+    let record = rh.read()?;
+    assert_eq!(record, expected_record);
+
+    Ok(())
+}
+
+#[test]
+fn test_file_append_record() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_file = copy_to_named_tmp_file("tests/data/stations.dbf")?;
+
+    let mut new_record = dbase::Record::default();
+    new_record.insert(
+        "name".to_string(),
+        dbase::FieldValue::Character(Some("Dalaran".to_string())),
+    );
+    new_record.insert(
+        "marker-col".to_string(),
+        dbase::FieldValue::Character(Some("#0f0f0f".to_string())),
+    );
+    new_record.insert(
+        "marker-sym".to_string(),
+        dbase::FieldValue::Character(Some("underground".to_string())),
+    );
+    new_record.insert(
+        "line".to_string(),
+        dbase::FieldValue::Character(Some("purple".to_string())),
+    );
+
+    {
+        let mut file = dbase::File::open_read_write(tmp_file.path())?;
+        assert_eq!(file.num_records(), 6);
+        file.append_record(&new_record)?;
+
+        assert_eq!(file.num_records(), 7);
+        let record = file.record(6).unwrap().read()?;
+        assert_eq!(record, new_record);
+    }
+
+    {
+        // Check that after closing the file, if we re-open it,
+        // our appended record is still here
+        let mut file = dbase::File::open_read_write(tmp_file.path())?;
+        assert_eq!(file.num_records(), 7);
+        let record = file.record(6).unwrap().read()?;
+        assert_eq!(record, new_record);
+    }
+
+    Ok(())
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -106,9 +106,10 @@ struct Album {
 }
 
 impl ReadableRecord for Album {
-    fn read_using<T>(field_iterator: &mut FieldIterator<T>) -> Result<Self, FieldIOError>
+    fn read_using<R1, R2>(field_iterator: &mut FieldIterator<R1, R2>) -> Result<Self, FieldIOError>
     where
-        T: Read + Seek,
+        R1: Read + Seek,
+        R2: Read + Seek,
     {
         Ok(Self {
             artist: field_iterator.read_next_field_as()?.value,


### PR DESCRIPTION
This new dbase::File struct allows to open a .dbf file in read or write or read+write mode.

This allows to read and modify a file
without having to first read eveything using dbase::Reader, make in memory modifications then write using dbase::TableWriter.


close #28 