### PR TITLE
support ASCIIZ encoding of field names

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -120,10 +120,14 @@ impl Encoding for Unicode {
 /// Tries to decode as ASCII, if unrepresentable characters are found, an [`Err`] is returned.
 impl Encoding for Ascii {
     fn decode<'a>(&self, bytes: &'a [u8]) -> Result<Cow<'a, str>, DecodeError> {
-        if bytes.is_ascii() {
+        // header can be ASCIIZ, terminated by \0, so only read up to this character
+        let zero_pos = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+        let str_bytes = &bytes[0..zero_pos];
+
+        if str_bytes.is_ascii() {
             // Since all ascii code points are compatible with utf-8
             // it is ok to unwrap here.
-            Ok(String::from_utf8(bytes.to_vec()).unwrap().into())
+            Ok(String::from_utf8(str_bytes.to_vec()).unwrap().into())
         } else {
             Err(DecodeError::NotAscii)
         }


### PR DESCRIPTION
I have a dbase file which I would like to read that uses ASCIIZ encoding for the field names (ASCII terminated by "\0" byte). Currently when reading this file, the crate panics with a "Not ASCII" error because the bytes following "\0" are garbage.

This change will read the field name only up to the first "\0" byte, which solves the issue.

These are the docs where I found the detail about the ASCIIZ encoding: https://www.fileformat.info/format/corion-dbase-iii.htm

Let me know if you would suggest any changes.

Cheers