### PR TITLE
Add TrimOption

### DIFF
--- a/src/field/types.rs
+++ b/src/field/types.rs
@@ -148,6 +148,7 @@ impl FieldValue {
         memo_reader: &mut Option<MemoReader<T>>,
         field_info: &FieldInfo,
         encoding: &E,
+        character_option: TrimOption,
     ) -> Result<Self, ErrorKind> {
         debug_assert_eq!(field_bytes.len(), field_info.length() as usize);
         let value = match field_info.field_type {
@@ -159,7 +160,7 @@ impl FieldValue {
             },
             FieldType::Character => {
                 // let value = read_string_of_len(&mut source, field_info.field_length)?;
-                let value = trim_field_data(field_bytes);
+                let value = trim_field_data(field_bytes, character_option);
                 if value.is_empty() {
                     FieldValue::Character(None)
                 } else {
@@ -168,7 +169,7 @@ impl FieldValue {
             }
             FieldType::Numeric => {
                 // let value = read_string_of_len(&mut source, field_info.field_length)?;
-                let value = trim_field_data(field_bytes);
+                let value = trim_field_data(field_bytes, TrimOption::BeginEnd);
                 if value.is_empty() || value.iter().all(|c| c == &b'*') {
                     FieldValue::Numeric(None)
                 } else {
@@ -178,7 +179,7 @@ impl FieldValue {
             }
             FieldType::Float => {
                 // let value = read_string_of_len(&mut source, field_info.field_length)?;
-                let value = trim_field_data(field_bytes);
+                let value = trim_field_data(field_bytes, TrimOption::BeginEnd);
                 if value.is_empty() || value.iter().all(|c| c == &b'*') {
                     FieldValue::Float(None)
                 } else {
@@ -188,7 +189,7 @@ impl FieldValue {
             }
             FieldType::Date => {
                 // let value = read_string_of_len(&mut source, field_info.field_length)?;
-                let value = trim_field_data(field_bytes);
+                let value = trim_field_data(field_bytes, TrimOption::BeginEnd);
                 if value.iter().all(|c| c == &b' ') {
                     FieldValue::Date(None)
                 } else {
@@ -218,7 +219,7 @@ impl FieldValue {
             FieldType::Memo => {
                 let index_in_memo = if field_info.field_length > 4 {
                     // let string = read_string_of_len(&mut source, field_info.field_length)?;
-                    let trimmed_value = trim_field_data(field_bytes);
+                    let trimmed_value = trim_field_data(field_bytes, TrimOption::End);
                     if trimmed_value.is_empty() {
                         return Ok(FieldValue::Memo(String::from("")));
                     } else {
@@ -895,7 +896,14 @@ mod ser {
     }
 }
 
-fn trim_field_data(bytes: &[u8]) -> &[u8] {
+#[derive(Copy, Clone, Debug)]
+pub enum TrimOption {
+    Begin,
+    End,
+    BeginEnd,
+}
+
+fn trim_field_data(bytes: &[u8], option: TrimOption) -> &[u8] {
     // Value in the dbf file is surrounded by space characters (32u8). We discard them before
     // parsing the bytes into string. Doing so doubles the performance in comparison to
     // using String::trim() afterwards.
@@ -929,7 +937,11 @@ fn trim_field_data(bytes: &[u8]) -> &[u8] {
     // Discarding spaces in front and at the end. The space character (32u8) is 00110000 in binary
     // format, which makes it safe to drop without checking, as it cannot be part of the multi-byte
     // UTF-8 symbol (all such bytes must start with 10).
-    &bytes[first..(last + 1)]
+    match option {
+        TrimOption::Begin => &bytes[first..],
+        TrimOption::End => &bytes[..last + 1],
+        TrimOption::BeginEnd => &bytes[first..last + 1],
+    }
 }
 
 #[cfg(test)]
@@ -965,6 +977,7 @@ mod test {
             &mut None,
             field_info,
             &encoding,
+            TrimOption::BeginEnd,
         )
         .unwrap();
         assert_eq!(value, &read_value);

--- a/src/header.rs
+++ b/src/header.rs
@@ -413,7 +413,7 @@ impl Header {
             None
         } else {
             let offset = self.offset_to_first_record as usize
-                + (index * self.size_of_record as usize)
+                + (index * (self.size_of_record as usize + DELETION_FLAG_SIZE))
                 + DELETION_FLAG_SIZE;
             Some(offset)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,11 +287,12 @@ pub use file::{FieldRef, File, RecordRef};
 pub use crate::datafusion::{DbaseTable, DbaseTableFactory};
 pub use crate::encoding::{Encoding, Unicode, UnicodeLossy};
 pub use crate::error::{Error, ErrorKind, FieldIOError};
-pub use crate::field::types::{Date, DateTime, FieldType, FieldValue, Time};
+pub use crate::field::types::{Date, DateTime, FieldType, FieldValue, Time, TrimOption};
 pub use crate::field::{FieldConversionError, FieldInfo, FieldName};
 pub use crate::header::CodePageMark;
 pub use crate::reading::{
-    read, FieldIterator, NamedValue, ReadableRecord, Reader, RecordIterator, TableInfo,
+    read, FieldIterator, NamedValue, ReadableRecord, Reader, ReadingOptions, RecordIterator,
+    TableInfo,
 };
 pub use crate::record::Record;
 pub use crate::writing::{FieldWriter, TableWriter, TableWriterBuilder, WritableRecord};

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use crate::encoding::DynEncoding;
 use crate::error::{Error, ErrorKind, FieldIOError};
-use crate::field::types::{FieldType, FieldValue};
+use crate::field::types::{FieldType, FieldValue, TrimOption};
 use crate::field::{DeletionFlag, FieldInfo};
 use crate::header::Header;
 use crate::memo::{MemoFileType, MemoReader};
@@ -49,6 +49,30 @@ pub struct TableInfo {
     pub(crate) encoding: DynEncoding,
 }
 
+/// Options related to reading
+#[derive(Copy, Clone, Debug)]
+pub struct ReadingOptions {
+    character_trim: TrimOption,
+}
+
+impl Default for ReadingOptions {
+    fn default() -> Self {
+        Self {
+            character_trim: TrimOption::BeginEnd,
+        }
+    }
+}
+
+impl ReadingOptions {
+    /// Customize how spaces ` ` are trimmed within [FieldValue::Charater]
+    ///
+    /// By default they are trimmed at the begining and the end
+    pub fn character_trim(mut self, trim_option: TrimOption) -> Self {
+        self.character_trim = trim_option;
+        self
+    }
+}
+
 /// Struct with the handle to the source .dbf file
 /// Responsible for reading the content
 // TODO Debug impl
@@ -60,6 +84,7 @@ pub struct Reader<T: Read + Seek> {
     header: Header,
     fields_info: Vec<FieldInfo>,
     encoding: DynEncoding,
+    options: ReadingOptions,
 }
 
 impl<T: Read + Seek> Reader<T> {
@@ -97,6 +122,7 @@ impl<T: Read + Seek> Reader<T> {
             header: file.header,
             fields_info: file.fields_info,
             encoding: file.encoding,
+            options: ReadingOptions::default(),
         })
     }
 
@@ -111,6 +137,10 @@ impl<T: Read + Seek> Reader<T> {
 
     pub fn set_encoding<E: Encoding + 'static>(&mut self, encoding: E) {
         self.encoding = DynEncoding::new(encoding);
+    }
+
+    pub fn set_options(&mut self, options: ReadingOptions) {
+        self.options = options;
     }
 
     /// Returns the header of the file
@@ -286,6 +316,7 @@ pub struct FieldIterator<'a, Source: Read + Seek, MemoSource: Read + Seek> {
     pub(crate) field_data_buffer: &'a mut [u8; 255],
     /// The string encoding
     pub(crate) encoding: &'a DynEncoding,
+    pub(crate) options: ReadingOptions,
 }
 
 impl<'a, Source: Read + Seek, MemoSource: Read + Seek> FieldIterator<'a, Source, MemoSource> {
@@ -399,6 +430,7 @@ impl<'a, Source: Read + Seek, MemoSource: Read + Seek> FieldIterator<'a, Source,
             self.memo_reader,
             field_info,
             &*self.encoding,
+            self.options.character_trim,
         ) {
             Ok(value) => Ok(value),
             Err(kind) => Err(FieldIOError {
@@ -472,6 +504,7 @@ impl<'a, T: Read + Seek, R: ReadableRecord> Iterator for RecordIterator<'a, T, R
                 memo_reader: &mut self.reader.memo_reader,
                 field_data_buffer: &mut self.field_data_buffer,
                 encoding: &self.reader.encoding,
+                options: self.reader.options,
             };
 
             let record = R::read_using(&mut iter)

--- a/tests/test_file.rs
+++ b/tests/test_file.rs
@@ -288,6 +288,52 @@ fn test_file_classical_user_record_example() -> Result<(), Box<dyn std::error::E
 }
 
 #[test]
+fn test_file_char_trimming() -> Result<(), Box<dyn std::error::Error>> {
+    dbase::dbase_record!(
+        #[derive(PartialOrd, PartialEq, Debug)]
+        struct StationRecord {
+            name: String,
+            marker_col: String,
+            marker_sym: String,
+            line: String,
+        }
+    );
+
+    let mut file = dbase::File::open_read_only("tests/data/stations.dbf")?;
+    let reading = dbase::ReadingOptions::default().character_trim(dbase::TrimOption::Begin);
+    file.set_options(reading);
+
+    let expected = StationRecord {
+        name: format!(
+            "{:width$}",
+            "Franconia-Springfield",
+            width = file.fields()[0].length() as usize
+        ),
+        marker_col: format!(
+            "{:width$}",
+            "#0000ff",
+            width = file.fields()[0].length() as usize
+        ),
+        marker_sym: format!(
+            "{:width$}",
+            "rail-metro",
+            width = file.fields()[0].length() as usize
+        ),
+        line: format!(
+            "{:width$}",
+            "blue",
+            width = file.fields()[0].length() as usize
+        ),
+    };
+
+    let record = file.record(1).unwrap().read_as::<StationRecord>()?;
+
+    assert_eq!(record, expected);
+
+    Ok(())
+}
+
+#[test]
 fn test_file_is_record_deleted() -> Result<(), Box<dyn std::error::Error>> {
     let mut file = dbase::File::open_read_only(STATIONS_WITH_DELETED)?;
 


### PR DESCRIPTION
Adds a `ReadingOption` that enables to choose how character fields should be trimmed.

Addresses #56 

~~- [ ] Put the encoding as a reading option ?~~
- [x] add builder pattern + non_exhaustive to prevent api breaks when adding new options later
- [x] docs
~~- [ ] Should options be per field ? ->  more complex to do~~