### PR TITLE
Adding a builder for Reader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,8 +298,8 @@ pub use crate::field::types::{Date, DateTime, FieldType, FieldValue, Time, TrimO
 pub use crate::field::{FieldConversionError, FieldInfo, FieldName};
 pub use crate::header::CodePageMark;
 pub use crate::reading::{
-    read, FieldIterator, NamedValue, ReadableRecord, Reader, ReadingOptions, RecordIterator,
-    TableInfo,
+    read, FieldIterator, NamedValue, ReadableRecord, Reader, ReaderBuilder, ReadingOptions,
+    RecordIterator, TableInfo,
 };
 pub use crate::record::Record;
 pub use crate::writing::{FieldWriter, TableWriter, TableWriterBuilder, WritableRecord};


### PR DESCRIPTION
I have cases where I need to read a dbf file with its memo file, but they are not available from a path (i.e from S3 or similar non-local-fs storage). I can still access them, but I need to be able to create a reader and attaching the memo source, and this seems convenient!
Thoughts?