### PR TITLE
Update datafusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ byteorder = "1.4.3"
 time = { version = "0.3", features = ["std"] }
 serde = { version = "1.0.102", optional = true }
 yore = { version = "1.0.1", optional = true }
-datafusion = { version = "20", optional = true }
-datafusion-expr = { version = "20", optional = true }
+datafusion = { version = "31", optional = true }
+datafusion-expr = { version = "31", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Updating datafusion to the latest version to take advantage of newly implemented SQL functions, e.g. `array_agg()`.

This required implementing the `DisplayAs` trait for `DbaseExec`. 

I've run `cargo test --features "datafusion"` and it passes without issue.

Let me know if you would suggest any changes, happy to update. Thanks