### PR TITLE
fix issue reading memo files with leading spaces

### DIFF
--- a/src/datafusion.rs
+++ b/src/datafusion.rs
@@ -8,7 +8,7 @@ use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::provider::TableProviderFactory;
 use datafusion::datasource::{TableProvider, TableType};
-use datafusion::error::Result;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::{SessionState, TaskContext};
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
 use datafusion::physical_plan::memory::MemoryStream;
@@ -257,9 +257,8 @@ impl ExecutionPlan for DbaseExec {
             if l >= self.limit {
                 break;
             }
-            let Some(r) = record.ok() else {
-                continue;
-            };
+
+            let r = record.map_err(|e| DataFusionError::Execution(e.to_string()))?;
 
             for i in 0..self.projections.len() {
                 match r.get(&dbase_field_names[self.projections[i]]).unwrap() {

--- a/src/field/types.rs
+++ b/src/field/types.rs
@@ -219,12 +219,11 @@ impl FieldValue {
             FieldType::Memo => {
                 let index_in_memo = if field_info.field_length > 4 {
                     // let string = read_string_of_len(&mut source, field_info.field_length)?;
-                    let trimmed_value = trim_field_data(field_bytes, TrimOption::End);
+                    let trimmed_value = trim_field_data(field_bytes, TrimOption::BeginEnd);
                     if trimmed_value.is_empty() {
                         return Ok(FieldValue::Memo(String::from("")));
                     } else {
                         encoding.decode(trimmed_value)?.parse::<u32>()?
-                        // string.parse::<u32>()?
                     }
                 } else {
                     let mut le_bytes = [0u8; std::mem::size_of::<u32>()];


### PR DESCRIPTION
Hi @tmontaigu,

I ran in to an error reading a dbase file with memo fields, so I have created this PR to fix. Changes are:

- raise error with datafusion if there is an error parsing a record. Previously these would be silently skipped, because I had assumed these cases were just empty records when they are not. 
- use `TrimOption::BeginEnd` instead of `TrimOption::End` when trying to get position in memo file. The dbase file I'm using had `trimmed_value` similar to the following, which would not be trimmed on the left and would then throw an error when parsing:

```
(10) &[32, 32, 32, 32, 32, 32, 32, 32, 32, 48]
```

Cheers