### PR TITLE
datafusion: use appropriate function to escape special chars in memo fields

### DIFF
--- a/src/datafusion.rs
+++ b/src/datafusion.rs
@@ -337,7 +337,7 @@ impl ExecutionPlan for DbaseExec {
                         .as_any_mut()
                         .downcast_mut::<StringBuilder>()
                         .unwrap()
-                        .append_value(m.escape_unicode().to_string()),
+                        .append_value(m.escape_default().to_string()),
                     FieldValue::Numeric(n) => match n {
                         Some(n) => column_builders[i]
                             .as_any_mut()


### PR DESCRIPTION
When reading memo fields I would get strings like `\u{57}\u{20}...` etc. because of the `escape_unicode()` function being used. This PR fixes this so that comprehensible text is returned.

Note that the reason for using the `escape_` function for memo fields in the first place is because they often contain newlines and other characters which interfere with CSV writing and printing when using datafusion. So, this is converting them to literal `\n`, `\t` etc.