### PR TITLE
fix for off by one error in file

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -4,7 +4,6 @@ use crate::encoding::DynEncoding;
 use std::io::{Read, Write};
 
 use crate::field::types::Date;
-use crate::field::DELETION_FLAG_SIZE;
 use crate::memo::MemoFileType;
 
 // Used this as source: https://blog.codetitans.pl/post/dbf-and-language-code-page/
@@ -406,17 +405,6 @@ impl Header {
         dest.write_u8(0)?;
         dest.write_u8(0)?;
         Ok(())
-    }
-
-    pub(crate) fn record_position(&self, index: usize) -> Option<usize> {
-        if index >= self.num_records as usize {
-            None
-        } else {
-            let offset = self.offset_to_first_record as usize
-                + (index * (self.size_of_record as usize + DELETION_FLAG_SIZE))
-                + DELETION_FLAG_SIZE;
-            Some(offset)
-        }
     }
 }
 


### PR DESCRIPTION
- move `record_position()` function from header.rs to file.rs
- calculate record size as sum of field lengths for all seeking / file operations, as it's unclear whether the record size from the header will include deletion flag or not. This effectively ignores the `record_length` from the header except when writing.

In the changes here, the `record_length` does not include the deletion flag, but I can update to include the deletion flag if that's preferred.