### PR TITLE
Faster file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ mod reading;
 mod record;
 mod writing;
 
-pub use file::{FieldRef, File, RecordRef};
+pub use file::{FieldIndex, FieldRef, File, RecordIndex, RecordRef};
 
 #[cfg(feature = "datafusion")]
 pub use crate::datafusion::{DbaseTable, DbaseTableFactory};

--- a/src/memo.rs
+++ b/src/memo.rs
@@ -9,6 +9,15 @@ pub(crate) enum MemoFileType {
     FoxBaseMemo,
 }
 
+impl MemoFileType {
+    pub(crate) const fn extension(self) -> &'static str {
+        match self {
+            MemoFileType::DbaseMemo | MemoFileType::DbaseMemo4 => "dbt",
+            MemoFileType::FoxBaseMemo => "fpt",
+        }
+    }
+}
+
 /// Although there are different memo file type with each a different
 /// header organisation, we use the same struct internally
 #[derive(Debug, Copy, Clone)]
@@ -45,7 +54,7 @@ impl MemoHeader {
 
 /// Struct that reads knows how to read data from a memo source
 #[derive(Debug, Clone)]
-pub(crate) struct MemoReader<T: Read + Seek> {
+pub(crate) struct MemoReader<T> {
     memo_file_type: MemoFileType,
     header: MemoHeader,
     source: T,

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -52,7 +52,7 @@ pub struct TableInfo {
 /// Options related to reading
 #[derive(Copy, Clone, Debug)]
 pub struct ReadingOptions {
-    character_trim: TrimOption,
+    pub(crate) character_trim: TrimOption,
 }
 
 impl Default for ReadingOptions {
@@ -152,7 +152,7 @@ impl<T: Read + Seek, E: Encoding + 'static> ReaderBuilder<T, E> {
             source: file.inner,
             memo_reader,
             header: file.header,
-            fields_info: file.fields_info,
+            fields_info: file.fields_info.inner,
             encoding: self
                 .encoding
                 .map_or_else(|| file.encoding, DynEncoding::new),
@@ -208,7 +208,7 @@ impl<T: Read + Seek> Reader<T> {
             source: file.inner,
             memo_reader: None,
             header: file.header,
-            fields_info: file.fields_info,
+            fields_info: file.fields_info.inner,
             encoding: file.encoding,
             options: ReadingOptions::default(),
         })
@@ -622,7 +622,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> Result<Vec<Record>, Error> {
 #[cfg(test)]
 mod test {
     use std::fs::File;
-    use std::io::{Seek, SeekFrom};
+    use std::io::Seek;
 
     use super::*;
 
@@ -630,7 +630,7 @@ mod test {
     fn pos_after_reading() {
         let file = File::open("tests/data/line.dbf").unwrap();
         let mut reader = Reader::new(file).unwrap();
-        let pos_after_reading = reader.source.seek(SeekFrom::Current(0)).unwrap();
+        let pos_after_reading = reader.source.stream_position().unwrap();
 
         let mut expected_pos = Header::SIZE + ((reader.fields_info.len()) * FieldInfo::SIZE);
         // Don't forget terminator


### PR DESCRIPTION
There is still some unwraps left in `File::record` function.

The choice is wether to change those unwraps and make `File::record` return a `Option<Result<Record, Error>>` but it makes
the caller do 2 unwraps (unless using while let Some)

or delay the seek / reading of data until either some FieldRef::write or read is called