### PR TITLE
Implements conversions of Date, Time and DateTime structs from and into chrono NaiveDate, NaiveTime and NaiveDateTime structs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ datafusion-expr = { version = "31", optional = true }
 async-trait = { version = "0.1", optional = true }
 codepage = { version = "0.1.2", optional = true }
 encoding_rs = { version = "0.8.35", optional = true }
+chrono = { version = "0.4.39", optional = true }
 
 [dev-dependencies]
 serde_derive = "1.0.102"
@@ -30,6 +31,7 @@ tokio = "1.26"
 datafusion = ["dep:datafusion", "dep:datafusion-expr", "dep:async-trait"]
 yore = ["dep:yore"]
 encoding_rs = ["dep:encoding_rs", "dep:codepage"]
+chrono = ["dep:chrono"]
 
 [[example]]
 name = "datafusion"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,9 @@ pub use crate::reading::{
 pub use crate::record::Record;
 pub use crate::writing::{FieldWriter, TableWriter, TableWriterBuilder, WritableRecord};
 
+#[cfg(feature = "chrono")]
+pub use crate::field::types::ChronoDateConversionError;
+
 /// macro to define a struct that implements the ReadableRecord and WritableRecord
 ///
 /// # Examples


### PR DESCRIPTION
This was described as an option in to add back behind a feature in  https://github.com/tmontaigu/dbase-rs/pull/35, which this PR does.