### PR TITLE
Use bufrw for the BufReadWriteFile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = { version = "0.1", optional = true }
 codepage = { version = "0.1.2", optional = true }
 encoding_rs = { version = "0.8.35", optional = true }
 chrono = { version = "0.4.39", optional = true }
+bufrw = "0.2.0"
 
 [dev-dependencies]
 serde_derive = "1.0.102"

--- a/tests/test_bugged_file_sync.rs
+++ b/tests/test_bugged_file_sync.rs
@@ -1,0 +1,91 @@
+use dbase::FieldName;
+use std::error::Error;
+
+dbase::dbase_record!(
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct DokumentRecord {
+        d_tip: Option<String>,
+        d_tipn: Option<String>,
+        d_broj: Option<String>,
+        d_konto: Option<String>,
+        d_firma: Option<String>,
+        d_mag: Option<String>,
+        d_zak: Option<String>,
+        d_otp: Option<String>,
+        d_fak: Option<String>,
+        d_knj: Option<bool>,
+    }
+);
+
+impl Default for DokumentRecord {
+    fn default() -> Self {
+        Self {
+            d_tip: Some("Yoshi".to_string()),
+            d_tipn: Some("Yoshi".to_string()),
+            d_broj: Some("Yoshi".to_string()),
+            d_konto: Some("Yoshi".to_string()),
+            d_firma: Some("Yoshi".to_string()),
+            d_mag: Some("Yoshi".to_string()),
+            d_zak: Some("Yoshi".to_string()),
+            d_otp: Some("Yoshi".to_string()),
+            d_fak: Some("Yoshi".to_string()),
+            d_knj: Some(true),
+        }
+    }
+}
+
+#[test]
+fn test_bugged_file_sync() -> Result<(), Box<dyn Error>> {
+    let document_path = "bugged-sync-file.dbf";
+
+    // Write file with default values
+    {
+        let mut writer = dbase::TableWriterBuilder::new()
+            .add_character_field(FieldName::try_from("d_tip").unwrap(), 255)
+            .add_character_field(FieldName::try_from("d_tipn").unwrap(), 255)
+            .add_character_field(FieldName::try_from("d_broj").unwrap(), 255)
+            .add_character_field(FieldName::try_from("d_konto").unwrap(), 255)
+            .add_character_field(FieldName::try_from("d_firma").unwrap(), 255)
+            .add_character_field(FieldName::try_from("d_mag").unwrap(), 255)
+            .add_character_field(FieldName::try_from("d_zak").unwrap(), 255)
+            .add_character_field(FieldName::try_from("d_otp").unwrap(), 255)
+            .add_character_field(FieldName::try_from("d_fak").unwrap(), 255)
+            .add_logical_field(FieldName::try_from("d_knj").unwrap())
+            .build_with_file_dest(document_path)
+            .unwrap();
+
+        let record = DokumentRecord::default();
+        for _ in 0..50_000 {
+            writer.write_record(&record).unwrap();
+        }
+
+        writer.finalize().unwrap();
+    }
+
+    // Rewrite a field of each record
+    {
+        let mut file = dbase::File::open_read_write(document_path)?;
+
+        let mut records = file.records();
+        while let Some(mut record) = records.next() {
+            let mut read_record: DokumentRecord = record.read_as()?;
+            read_record.d_firma = Some("Luigi".to_string());
+            record.write(&read_record)?;
+        }
+    }
+
+    // Read file and check if the field was rewritten
+    // Without the fix, the field will not have been modified
+    {
+        let expected = Some("Luigi".to_string());
+        let mut reader = dbase::Reader::from_path(document_path).unwrap();
+        for record in reader.iter_records_as::<DokumentRecord>() {
+            let record = record.unwrap();
+            assert_eq!(record.d_firma, expected);
+        }
+    }
+
+    std::fs::remove_file(document_path)?;
+
+    Ok(())
+}


### PR DESCRIPTION
The implementation of BufReadWriteFile in order
to have buffered read and write on a std::fs::File was made in a 'hacky' using 2 files and 1 BufReader and a BufWriter, this impl was not completely correct.

Indeed there was a synchronization bug that was happening in release build but not in debug build because a debug_assert called a method that would force the synchronization.

So we replace this by BufReaderWriter type from the bufrw crate which should not properly implement buffered read + write