### PR TITLE
Use Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 keywords = ["dbase", "dbf"]
 homepage = "https://github.com/tmontaigu/dbase-rs"
 repository = "https://github.com/tmontaigu/dbase-rs"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 byteorder = "1.4.3"

--- a/src/datafusion.rs
+++ b/src/datafusion.rs
@@ -1,4 +1,4 @@
-use crate::{file::BufReadWriteFile, FieldType, FieldValue, File as DbaseFile};
+use crate::{FieldType, FieldValue, File as DbaseFile, file::BufReadWriteFile};
 use async_trait::async_trait;
 use datafusion::arrow::array::{
     ArrayBuilder, ArrayRef, BooleanBuilder, Date32Builder, Float32Builder, Float64Builder,
@@ -18,8 +18,8 @@ use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType, Partitioning};
 use datafusion::physical_plan::memory::MemoryStream;
 use datafusion::physical_plan::{
-    project_schema, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
-    SendableRecordBatchStream,
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
+    project_schema,
 };
 use datafusion::prelude::*;
 use datafusion_expr::CreateExternalTable;

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 use std::io::{Read, Seek};
 
-use serde::de::{DeserializeOwned, DeserializeSeed, IntoDeserializer, SeqAccess, Visitor};
 use serde::Deserializer;
+use serde::de::{DeserializeOwned, DeserializeSeed, IntoDeserializer, SeqAccess, Visitor};
 
 use crate::{
     ErrorKind, FieldConversionError, FieldIOError, FieldIterator, FieldValue, ReadableRecord,

--- a/src/error.rs
+++ b/src/error.rs
@@ -213,7 +213,7 @@ impl std::fmt::Display for ErrorKind {
             ErrorKind::UnsupportedCodePage(code) => {
                 write!(f, "The code page '{code:?}' is not supported")
             }
-            ErrorKind::Message(ref msg) => write!(f, "{msg}"),
+            ErrorKind::Message(msg) => write!(f, "{msg}"),
         }
     }
 }

--- a/src/field/conversion.rs
+++ b/src/field/conversion.rs
@@ -1,4 +1,4 @@
-use super::{types, FieldType, FieldValue};
+use super::{FieldType, FieldValue, types};
 
 /// Errors that can happen when trying to convert a FieldValue into
 /// a more concrete type

--- a/src/field/types.rs
+++ b/src/field/types.rs
@@ -4,11 +4,11 @@ use std::fmt::Display;
 use std::io::{Read, Seek, Write};
 use std::str::FromStr;
 
+use crate::Encoding;
 use crate::error::ErrorKind;
 use crate::field::FieldInfo;
 use crate::memo::MemoReader;
 use crate::writing::WritableAsDbaseField;
-use crate::Encoding;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 #[cfg(feature = "chrono")]
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
@@ -872,8 +872,8 @@ impl WritableAsDbaseField for DateTime {
 #[cfg(feature = "serde")]
 mod de {
     use super::*;
-    use serde::de::{Deserialize, Visitor};
     use serde::Deserializer;
+    use serde::de::{Deserialize, Visitor};
     use std::io::Cursor;
 
     impl<'de> Deserialize<'de> for Date {
@@ -936,8 +936,8 @@ mod de {
 mod ser {
     use super::*;
 
-    use serde::ser::Serialize;
     use serde::Serializer;
+    use serde::ser::Serialize;
 
     impl Serialize for Date {
         fn serialize<S>(

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,10 +1,10 @@
+use crate::ErrorKind::UnsupportedCodePage;
 use crate::encoding::DynEncoding;
-use crate::field::{DeletionFlag, FieldsInfo, DELETION_FLAG_SIZE};
+use crate::field::{DELETION_FLAG_SIZE, DeletionFlag, FieldsInfo};
 use crate::header::Header;
 use crate::memo::MemoReader;
-use crate::reading::{ReadingOptions, BACKLINK_SIZE, TERMINATOR_VALUE};
-use crate::writing::{write_header_parts, WritableAsDbaseField};
-use crate::ErrorKind::UnsupportedCodePage;
+use crate::reading::{BACKLINK_SIZE, ReadingOptions, TERMINATOR_VALUE};
+use crate::writing::{WritableAsDbaseField, write_header_parts};
 use crate::{
     Encoding, Error, ErrorKind, FieldConversionError, FieldIOError, FieldInfo, FieldIterator,
     FieldValue, FieldWriter, ReadableRecord, TableInfo, WritableRecord,
@@ -757,24 +757,30 @@ mod tests {
             let mut record = file.record(0).unwrap();
             let _ = record.read_field(crate::FieldIndex(0)).unwrap();
             // Must return false, meaning it correctly understands the record 0 is in memory
-            assert!(!file
-                .ensure_record_has_been_read_into_buffer(crate::RecordIndex(0))
-                .unwrap());
-            assert!(file
-                .ensure_record_has_been_read_into_buffer(crate::RecordIndex(1))
-                .unwrap());
+            assert!(
+                !file
+                    .ensure_record_has_been_read_into_buffer(crate::RecordIndex(0))
+                    .unwrap()
+            );
+            assert!(
+                file.ensure_record_has_been_read_into_buffer(crate::RecordIndex(1))
+                    .unwrap()
+            );
         }
 
         {
             let mut record = file.record(4).unwrap();
             let _ = record.read_field(crate::FieldIndex(3)).unwrap();
             // Must return false, meaning it correctly understands the record 4 is in memory
-            assert!(!file
-                .ensure_record_has_been_read_into_buffer(crate::RecordIndex(4))
-                .unwrap());
-            assert!(file
-                .ensure_record_has_been_read_into_buffer(crate::RecordIndex(1))
-                .unwrap());
+            assert!(
+                !file
+                    .ensure_record_has_been_read_into_buffer(crate::RecordIndex(4))
+                    .unwrap()
+            );
+            assert!(
+                file.ensure_record_has_been_read_into_buffer(crate::RecordIndex(1))
+                    .unwrap()
+            );
         }
 
         // Make sure writing a field still work with the ensure mechanism
@@ -782,14 +788,18 @@ mod tests {
             let mut record = file.record(10).unwrap();
             let value = record.read_field(crate::FieldIndex(2)).unwrap();
             // Use record.file to avoid double borrow
-            assert!(!record
-                .file
-                .ensure_record_has_been_read_into_buffer(crate::RecordIndex(10))
-                .unwrap());
+            assert!(
+                !record
+                    .file
+                    .ensure_record_has_been_read_into_buffer(crate::RecordIndex(10))
+                    .unwrap()
+            );
             record.write_field(crate::FieldIndex(2), &value).unwrap();
-            assert!(!file
-                .ensure_record_has_been_read_into_buffer(crate::RecordIndex(10))
-                .unwrap());
+            assert!(
+                !file
+                    .ensure_record_has_been_read_into_buffer(crate::RecordIndex(10))
+                    .unwrap()
+            );
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,8 +338,8 @@ pub use crate::field::types::{Date, DateTime, FieldType, FieldValue, Time, TrimO
 pub use crate::field::{FieldConversionError, FieldInfo, FieldName};
 pub use crate::header::CodePageMark;
 pub use crate::reading::{
-    read, FieldIterator, NamedValue, ReadableRecord, Reader, ReaderBuilder, ReadingOptions,
-    RecordIterator, TableInfo,
+    FieldIterator, NamedValue, ReadableRecord, Reader, ReaderBuilder, ReadingOptions,
+    RecordIterator, TableInfo, read,
 };
 pub use crate::record::Record;
 pub use crate::writing::{FieldWriter, TableWriter, TableWriterBuilder, WritableRecord};

--- a/src/memo.rs
+++ b/src/memo.rs
@@ -114,12 +114,11 @@ impl<T: Read + Seek> MemoReader<T> {
                 }
             }
             MemoFileType::DbaseMemo => {
-                if let Err(e) = self.source.read_exact(&mut self.internal_buffer) {
-                    if index != self.header.next_available_block_index - 1
-                        && e.kind() != std::io::ErrorKind::UnexpectedEof
-                    {
-                        return Err(e);
-                    }
+                if let Err(e) = self.source.read_exact(&mut self.internal_buffer)
+                    && index != self.header.next_available_block_index - 1
+                    && e.kind() != std::io::ErrorKind::UnexpectedEof
+                {
+                    return Err(e);
                 }
                 match self.internal_buffer.iter().position(|b| *b == 0x1A) {
                     Some(pos) => Ok(&self.internal_buffer[..pos]),

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,6 +1,6 @@
 use crate::{FieldIOError, FieldIterator, FieldValue, NamedValue, ReadableRecord};
-use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
+use std::collections::hash_map::RandomState;
 use std::io::{Read, Seek};
 
 /// Type definition of a generic record.

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -6,10 +6,10 @@ use std::path::Path;
 use byteorder::WriteBytesExt;
 
 use crate::encoding::{AsCodePageMark, DynEncoding};
-use crate::field::{types::FieldType, DeletionFlag, FieldInfo, FieldName};
+use crate::field::{DeletionFlag, FieldInfo, FieldName, types::FieldType};
 use crate::header::Header;
 use crate::reading::TERMINATOR_VALUE;
-use crate::reading::{TableInfo, BACKLINK_SIZE};
+use crate::reading::{BACKLINK_SIZE, TableInfo};
 use crate::{Encoding, Error, ErrorKind, FieldIOError, Record, UnicodeLossy};
 
 /// A dbase file ends with this byte


### PR DESCRIPTION
I don't see strong reason to migrate to Rust 2024, but probably now it's stable enough to migrate.

There was only one error that I had to address due to the migration. The let chain is suggested by cargo clippy.

```
error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> src\error.rs:216:32
    |
216 |             ErrorKind::Message(ref msg) => write!(f, "{msg}"),
    |                                ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
    = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> src\error.rs:216:13
    |
216 |             ErrorKind::Message(ref msg) => write!(f, "{msg}"),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
help: remove the unnecessary binding modifier
    |
216 -             ErrorKind::Message(ref msg) => write!(f, "{msg}"),
216 +             ErrorKind::Message(msg) => write!(f, "{msg}"),
    |

error: could not compile `dbase` (lib) due to 1 previous error
```