### PR TITLE
Use 0x13 for CP932

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -158,6 +158,7 @@ impl From<u8> for CodePageMark {
             0x01 => Self::CP437,
             0x02 => Self::CP850,
             0x03 => Self::CP1252,
+            0x13 => Self::CP932,
             0x4D => Self::CP936,
             // 0x04 => Self::StandardMacIntosh,
             0x64 => Self::CP852,
@@ -206,7 +207,9 @@ impl From<CodePageMark> for u8 {
             CodePageMark::CP950 => 0x78,
             CodePageMark::CP949 => 0x79,
             CodePageMark::CP936 => 0x7A,
-            CodePageMark::CP932 => 0x7B,
+            // For an unknown reason, CP932 has two LDIDs; 0x13 and 0x7B.
+            // We don't know which is appropriate, but it seems 0x13 is used in actual.
+            CodePageMark::CP932 => 0x13,
             CodePageMark::CP874 => 0x7C,
             CodePageMark::CP1255 => 0x7D,
             CodePageMark::CP1256 => 0x7E,


### PR DESCRIPTION
For unknown reason, CP932 has two corresponding language driver IDs. (`0x13` and `0x7B`).

https://github.com/postgis/postgis/blob/5fac7d16ab444240d465a36d717b4f0b95c068dd/loader/shpcommon.c#L54
https://github.com/infused/dbf/blob/4599d008251a048ccff623c06aaa5c8e62825e1f/lib/dbf/encodings.rb#L18

dbase-rs currently uses `0x7B`, but, from my observation, it seems `0x13` is used in the actual data.

- [The official guide by ESRI Japan](https://github.com/EsriJapan/shapefile_info) says the LDID for CP932 is 13
- The DBF files distributed on e-Stat, the portal site of japanese government statistics, uses `0x13`.

So, this pull request changes the behaviours of the reader and the writer to:

- the reader recognizes `0x13` as CP932 in addition to `0x7B` (no breaking change)
- the writer writes `0x13` instead of `0x7B` (breaking change)