### PR TITLE
refactor error type

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -4,16 +4,14 @@ use std::io::{Read, Seek};
 use serde::Deserializer;
 use serde::de::{DeserializeOwned, DeserializeSeed, IntoDeserializer, SeqAccess, Visitor};
 
-use crate::{
-    ErrorKind, FieldConversionError, FieldIOError, FieldIterator, FieldValue, ReadableRecord,
-};
+use crate::{ErrorKind, FieldError, FieldIterator, FieldValue, ReadableRecord};
 
 impl<'de, 'a, R1, R2> SeqAccess<'de> for &mut FieldIterator<'a, R1, R2>
 where
     R1: Read + Seek,
     R2: Read + Seek,
 {
-    type Error = FieldIOError;
+    type Error = FieldError;
 
     fn next_element_seed<T>(
         &mut self,
@@ -22,7 +20,7 @@ where
     where
         T: DeserializeSeed<'de>,
     {
-        if self.fields_info.peek().is_none() {
+        if self.fields_info.get(self.next_index.0).is_none() {
             Ok(None)
         } else {
             seed.deserialize(&mut **self).map(Some)
@@ -35,13 +33,13 @@ where
     T: Read + Seek,
     R: Read + Seek,
 {
-    type Error = FieldIOError;
+    type Error = FieldError;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        Err(FieldConversionError::IncompatibleType.into())
+        Err(FieldError::without_context(ErrorKind::IncompatibleType))
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
@@ -56,94 +54,56 @@ where
     where
         V: Visitor<'de>,
     {
-        let value = self.read_next_field_as::<i32>()?.value;
-        visitor.visit_i8(
-            value
-                .try_into()
-                .ok()
-                .ok_or(FieldConversionError::IncompatibleType)?,
-        )
+        visitor.visit_i8(self.read_next_field_as::<i8>()?.value)
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let value = self.read_next_field_as::<i32>()?.value;
-        visitor.visit_i16(
-            value
-                .try_into()
-                .ok()
-                .ok_or(FieldConversionError::IncompatibleType)?,
-        )
+        visitor.visit_i16(self.read_next_field_as::<i16>()?.value)
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let value = self.read_next_field_as::<i32>()?.value;
-        visitor.visit_i32(value)
+        visitor.visit_i32(self.read_next_field_as::<i32>()?.value)
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let value = self.read_next_field_as::<i32>()?.value;
-        visitor.visit_i64(value.into())
+        visitor.visit_i64(self.read_next_field_as::<i64>()?.value)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let value = self.read_next_field_as::<i32>()?.value;
-        visitor.visit_u8(
-            value
-                .try_into()
-                .ok()
-                .ok_or(FieldConversionError::IncompatibleType)?,
-        )
+        visitor.visit_u8(self.read_next_field_as::<u8>()?.value)
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let value = self.read_next_field_as::<i32>()?.value;
-        visitor.visit_u16(
-            value
-                .try_into()
-                .ok()
-                .ok_or(FieldConversionError::IncompatibleType)?,
-        )
+        visitor.visit_u16(self.read_next_field_as::<u16>()?.value)
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let value = self.read_next_field_as::<i32>()?.value;
-        visitor.visit_u32(
-            value
-                .try_into()
-                .ok()
-                .ok_or(FieldConversionError::IncompatibleType)?,
-        )
+        visitor.visit_u32(self.read_next_field_as::<u32>()?.value)
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let value = self.read_next_field_as::<i32>()?.value;
-        visitor.visit_u64(
-            value
-                .try_into()
-                .ok()
-                .ok_or(FieldConversionError::IncompatibleType)?,
-        )
+        visitor.visit_u64(self.read_next_field_as::<u64>()?.value)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value, Self::Error>
@@ -170,7 +130,7 @@ where
         let mut chars = value.chars();
         match (chars.next(), chars.next()) {
             (Some(c), None) => visitor.visit_char(c),
-            _ => Err(FieldConversionError::IncompatibleType.into()),
+            _ => Err(FieldError::without_context(ErrorKind::IncompatibleType)),
         }
     }
 
@@ -361,7 +321,7 @@ where
 }
 
 impl<S: DeserializeOwned> ReadableRecord for S {
-    fn read_using<T, R>(field_iterator: &mut FieldIterator<T, R>) -> Result<Self, FieldIOError>
+    fn read_using<T, R>(field_iterator: &mut FieldIterator<T, R>) -> Result<Self, FieldError>
     where
         T: Read + Seek,
         R: Read + Seek,
@@ -370,11 +330,8 @@ impl<S: DeserializeOwned> ReadableRecord for S {
     }
 }
 
-impl serde::de::Error for FieldIOError {
+impl serde::de::Error for FieldError {
     fn custom<T: Display>(msg: T) -> Self {
-        Self {
-            field: None,
-            kind: ErrorKind::Message(msg.to_string()),
-        }
+        Self::without_context(ErrorKind::Message(msg.to_string()))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
-use crate::{CodePageMark, FieldConversionError, FieldInfo, field::types::TimeError};
+use crate::{
+    CodePageMark, FieldConversionError, FieldIndex, FieldInfo, FieldType, RecordIndex,
+    field::types::TimeError,
+};
 use std::string::FromUtf8Error;
 
 #[derive(Debug)]
@@ -43,38 +46,149 @@ pub enum ErrorKind {
     Message(String),
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct FieldContext {
+    pub(crate) index: FieldIndex,
+    pub(crate) name: String,
+    pub(crate) kind: FieldType,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RecordField {
+    DeletionFlag,
+    Field(FieldContext),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RecordContext {
+    index: RecordIndex,
+    field: Option<RecordField>,
+}
+
+#[derive(Debug)]
+pub struct FieldError {
+    pub(crate) kind: ErrorKind,
+    pub(crate) context: Option<FieldContext>,
+}
+
+impl FieldError {
+    pub fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
+}
+
+impl FieldError {
+    pub(crate) fn from_info(
+        index: FieldIndex,
+        info: &FieldInfo,
+        err: impl Into<ErrorKind>,
+    ) -> Self {
+        Self {
+            kind: err.into(),
+            context: Some(FieldContext {
+                index,
+                name: info.name.clone(),
+                kind: info.field_type(),
+            }),
+        }
+    }
+
+    pub(crate) const fn end_of_record() -> Self {
+        Self {
+            kind: ErrorKind::EndOfRecord,
+            context: None,
+        }
+    }
+
+    pub(crate) fn without_context(kind: impl Into<ErrorKind>) -> Self {
+        Self {
+            kind: kind.into(),
+            context: None,
+        }
+    }
+}
+
+impl std::error::Error for FieldError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.kind.source()
+    }
+}
+
+impl std::fmt::Display for FieldError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.context {
+            Some(FieldContext { index, name, kind }) => {
+                write!(
+                    f,
+                    "An error occurred at field #{} ('{name}', {kind}): {}",
+                    index.0, self.kind
+                )
+            }
+            None => write!(f, "An error occurred for a field: {}", self.kind),
+        }
+    }
+}
+
 /// The error type for this crate
 #[derive(Debug)]
 pub struct Error {
-    pub(crate) record_num: usize,
-    pub(crate) field: Option<FieldInfo>,
     pub(crate) kind: ErrorKind,
+    pub(crate) record_context: Option<RecordContext>,
 }
 
 impl Error {
-    pub(crate) fn new(field_error: FieldIOError, current_record: usize) -> Self {
-        Self {
-            record_num: current_record,
-            field: field_error.field,
-            kind: field_error.kind,
-        }
-    }
-
-    pub(crate) fn io_error(error: std::io::Error, current_record: usize) -> Self {
-        Self {
-            record_num: current_record,
-            field: None,
-            kind: ErrorKind::IoError(error),
-        }
-    }
-
     /// Shortcut for when the error happens before parsing the fields
-    /// e.g. when parsing header
-    pub(crate) fn pre_fields(kind: ErrorKind) -> Self {
+    /// i.e when parsing header
+    pub(crate) fn header(kind: impl Into<ErrorKind>) -> Self {
         Self {
-            record_num: 0,
-            field: None,
-            kind,
+            kind: kind.into(),
+            record_context: None,
+        }
+    }
+
+    /// Shortcut for when the error happens at the 'global' record level
+    /// for example when reading the whole record into a buffer, seeking to the
+    /// beginning of the record, etc
+    pub(crate) fn record(record_index: RecordIndex, kind: impl Into<ErrorKind>) -> Self {
+        Self {
+            kind: kind.into(),
+            record_context: Some(RecordContext {
+                index: record_index,
+                field: None,
+            }),
+        }
+    }
+
+    pub(crate) fn deletion_flag(record_index: RecordIndex, kind: impl Into<ErrorKind>) -> Self {
+        Self {
+            kind: kind.into(),
+            record_context: Some(RecordContext {
+                index: record_index,
+                field: Some(RecordField::DeletionFlag),
+            }),
+        }
+    }
+
+    /// Most complete error, for when it happened when reading a field
+    pub(crate) fn field(
+        record_index: RecordIndex,
+        field_ctx: FieldContext,
+        kind: impl Into<ErrorKind>,
+    ) -> Self {
+        Self {
+            kind: kind.into(),
+            record_context: Some(RecordContext {
+                index: record_index,
+                field: Some(RecordField::Field(field_ctx)),
+            }),
+        }
+    }
+
+    pub(crate) fn from_field_error(index: RecordIndex, error: FieldError) -> Self {
+        let FieldError { kind, context } = error;
+        match context {
+            Some(c) => Self::field(index, c, kind),
+            None => Self::record(index, kind),
         }
     }
 
@@ -83,40 +197,27 @@ impl Error {
         &self.kind
     }
 
-    /// Returns the index of record index for which the error occurred
+    /// Returns record index for which the error occurred
     ///
-    /// 0 may be the first record or an error that occurred before
-    /// handling the first record (eg: an error reading the header)
-    pub fn record_num(&self) -> usize {
-        self.record_num
+    /// None means the error happened outside of reading/writing a record, mainly
+    /// when reading the header
+    pub fn record_index(&self) -> Option<RecordIndex> {
+        self.record_context.as_ref().map(|ctx| ctx.index)
     }
 
-    /// Returns the information of the record field for which the error occurred
-    pub fn field(&self) -> &Option<FieldInfo> {
-        &self.field
-    }
-}
-
-#[derive(Debug)]
-pub struct FieldIOError {
-    pub(crate) field: Option<FieldInfo>,
-    pub(crate) kind: ErrorKind,
-}
-
-impl FieldIOError {
-    pub fn new(kind: ErrorKind, field: Option<FieldInfo>) -> Self {
-        Self { field, kind }
-    }
-
-    pub(crate) fn end_of_record() -> Self {
-        Self {
-            field: None,
-            kind: ErrorKind::EndOfRecord,
-        }
-    }
-
-    pub fn kind(&self) -> &ErrorKind {
-        &self.kind
+    /// Returns the field index for which the error occurred
+    ///
+    /// None means the error happened outside of reading/writing a field
+    pub fn field_index(&self) -> Option<FieldIndex> {
+        self.record_context.as_ref().and_then(|ctx| {
+            ctx.field.as_ref().and_then(|f| {
+                if let RecordField::Field(ctx) = f {
+                    Some(ctx.index)
+                } else {
+                    None
+                }
+            })
+        })
     }
 }
 
@@ -168,31 +269,62 @@ impl From<TimeError> for ErrorKind {
     }
 }
 
-impl From<FieldConversionError> for FieldIOError {
-    fn from(e: FieldConversionError) -> Self {
-        FieldIOError::new(ErrorKind::BadConversion(e), None)
+impl ErrorKind {
+    pub(crate) fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ErrorKind::IoError(e) => Some(e),
+            ErrorKind::ParseFloatError(e) => Some(e),
+            ErrorKind::ParseIntError(e) => Some(e),
+            ErrorKind::InvalidDate(e) => Some(e),
+            ErrorKind::InvalidTime(e) => Some(e),
+            ErrorKind::ErrorOpeningMemoFile(e) => Some(e),
+            ErrorKind::BadConversion(e) => Some(e),
+            ErrorKind::StringDecodeError(e) => Some(e),
+            ErrorKind::StringEncodeError(e) => Some(e),
+            _ => None,
+        }
     }
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(field_info) = &self.field {
-            write!(
-                f,
-                "Error {{ record_num: {}, kind: {}, {} }}",
-                self.record_num, self.kind, field_info
-            )
+        if let Some(ctx) = &self.record_context {
+            match &ctx.field {
+                Some(record_field) => match record_field {
+                    RecordField::DeletionFlag => {
+                        write!(
+                            f,
+                            "An error occurred in record {} at deletion flag: {}",
+                            ctx.index.0, self.kind
+                        )
+                    }
+                    RecordField::Field(FieldContext { index, name, kind }) => {
+                        write!(
+                            f,
+                            "An error occurred in record {} at field #{} ('{name}', {kind}): {}",
+                            ctx.index.0, index.0, self.kind
+                        )
+                    }
+                },
+                None => {
+                    write!(
+                        f,
+                        "An error occurred in record {}: {}",
+                        ctx.index.0, self.kind
+                    )
+                }
+            }
         } else {
-            write!(
-                f,
-                "Error {{ record_num: {}, kind: {} }}",
-                self.record_num, self.kind
-            )
+            write!(f, "Error {{ kind: {} }}", self.kind)
         }
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.kind.source()
+    }
+}
 
 impl std::fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -247,18 +379,6 @@ impl std::fmt::Display for ErrorKind {
     }
 }
 
-impl std::fmt::Display for FieldIOError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(field_info) = &self.field {
-            write!(f, "FieldIOError {{ kind: {}, {} }}", self.kind, field_info)
-        } else {
-            write!(f, "FieldIOError {{ kind: {:?} }}", self.kind)
-        }
-    }
-}
-
-impl std::error::Error for FieldIOError {}
-
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum DecodeError {
@@ -284,7 +404,13 @@ impl From<yore::DecodeError> for DecodeError {
 
 impl std::fmt::Display for DecodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
+        match self {
+            DecodeError::Message(msg) => write!(f, "{msg}"),
+            DecodeError::FromUtf8(e) => write!(f, "{e}"),
+            DecodeError::NotAscii => write!(f, "string contains non-ASCII bytes"),
+            #[cfg(feature = "yore")]
+            DecodeError::Yore(e) => write!(f, "{e}"),
+        }
     }
 }
 
@@ -313,7 +439,11 @@ impl From<yore::EncodeError> for EncodeError {
 
 impl std::fmt::Display for EncodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
+        match self {
+            EncodeError::Message(msg) => write!(f, "{msg}"),
+            #[cfg(feature = "yore")]
+            EncodeError::Yore(e) => write!(f, "{e}"),
+        }
     }
 }
 

--- a/src/field/conversion.rs
+++ b/src/field/conversion.rs
@@ -22,7 +22,7 @@ impl std::fmt::Display for FieldConversionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FieldConversionError::FieldTypeNotAsExpected { expected, actual } => {
-                write!(f, "Cannot convert from {expected} to {actual}")
+                write!(f, "Cannot convert from {actual} to {expected}")
             }
             FieldConversionError::IncompatibleType => write!(f, "The type is not compatible"),
             FieldConversionError::NoneValue => {
@@ -84,6 +84,67 @@ impl_try_from_field_value_for_!(FieldValue::Logical => Option<bool>);
 impl_try_from_field_value_for_!(FieldValue::Logical(Some(b)) => bool);
 
 impl_try_from_field_value_for_!(FieldValue::Integer => i32);
+
+impl TryFrom<FieldValue> for i8 {
+    type Error = FieldConversionError;
+    fn try_from(value: FieldValue) -> Result<Self, Self::Error> {
+        i32::try_from(value)?
+            .try_into()
+            .map_err(|_| FieldConversionError::IncompatibleType)
+    }
+}
+
+impl TryFrom<FieldValue> for i16 {
+    type Error = FieldConversionError;
+    fn try_from(value: FieldValue) -> Result<Self, Self::Error> {
+        i32::try_from(value)?
+            .try_into()
+            .map_err(|_| FieldConversionError::IncompatibleType)
+    }
+}
+
+impl TryFrom<FieldValue> for u8 {
+    type Error = FieldConversionError;
+    fn try_from(value: FieldValue) -> Result<Self, Self::Error> {
+        i32::try_from(value)?
+            .try_into()
+            .map_err(|_| FieldConversionError::IncompatibleType)
+    }
+}
+
+impl TryFrom<FieldValue> for u16 {
+    type Error = FieldConversionError;
+    fn try_from(value: FieldValue) -> Result<Self, Self::Error> {
+        i32::try_from(value)?
+            .try_into()
+            .map_err(|_| FieldConversionError::IncompatibleType)
+    }
+}
+
+impl TryFrom<FieldValue> for u32 {
+    type Error = FieldConversionError;
+    fn try_from(value: FieldValue) -> Result<Self, Self::Error> {
+        i32::try_from(value)?
+            .try_into()
+            .map_err(|_| FieldConversionError::IncompatibleType)
+    }
+}
+
+impl TryFrom<FieldValue> for u64 {
+    type Error = FieldConversionError;
+    fn try_from(value: FieldValue) -> Result<Self, Self::Error> {
+        i32::try_from(value)?
+            .try_into()
+            .map_err(|_| FieldConversionError::IncompatibleType)
+    }
+}
+
+impl TryFrom<FieldValue> for i64 {
+    type Error = FieldConversionError;
+    fn try_from(value: FieldValue) -> Result<Self, Self::Error> {
+        i32::try_from(value).map(i64::from)
+    }
+}
 
 impl TryFrom<FieldValue> for f64 {
     type Error = FieldConversionError;

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,12 +1,13 @@
 use crate::ErrorKind::UnsupportedCodePage;
 use crate::encoding::DynEncoding;
+use crate::error::FieldContext;
 use crate::field::{DELETION_FLAG_SIZE, DeletionFlag, FieldsInfo};
 use crate::header::Header;
 use crate::memo::MemoReader;
 use crate::reading::{BACKLINK_SIZE, ReadingOptions};
 use crate::writing::{WritableAsDbaseField, write_header_parts};
 use crate::{
-    Encoding, Error, ErrorKind, FieldConversionError, FieldIOError, FieldInfo, FieldIterator,
+    Encoding, Error, ErrorKind, FieldConversionError, FieldError, FieldInfo, FieldIterator,
     FieldValue, FieldWriter, ReadableRecord, TableInfo, WritableRecord,
 };
 use byteorder::ReadBytesExt;
@@ -66,13 +67,11 @@ impl<T> FieldRef<'_, T>
 where
     T: Seek,
 {
-    fn seek_to_beginning(&mut self) -> Result<u64, FieldIOError> {
-        let field_info = &self.file.fields_info[self.field_index.0];
-
+    fn seek_to_beginning(&mut self) -> Result<u64, ErrorKind> {
         self.file
             .inner
             .seek(SeekFrom::Start(self.position_in_source()))
-            .map_err(|e| FieldIOError::new(ErrorKind::IoError(e), Some(field_info.clone())))
+            .map_err(ErrorKind::IoError)
     }
 }
 
@@ -99,9 +98,14 @@ where
             self.file.options.character_trim,
         )
         .map_err(|e| {
-            Error::new(
-                FieldIOError::new(e, Some(field_info.clone())),
-                self.record_index.0,
+            Error::field(
+                self.record_index,
+                FieldContext {
+                    index: self.field_index,
+                    name: field_info.name.clone(),
+                    kind: field_info.field_type(),
+                },
+                e,
             )
         })
     }
@@ -115,9 +119,15 @@ where
 
         let converted_value = ValueType::try_from(value).map_err(|e| {
             let field_info = &self.file.fields_info[self.field_index.0];
-            Error::new(
-                FieldIOError::new(ErrorKind::BadConversion(e), Some(field_info.clone())),
-                self.record_index.0,
+
+            Error::field(
+                self.record_index,
+                FieldContext {
+                    index: self.field_index,
+                    name: field_info.name.clone(),
+                    kind: field_info.field_type(),
+                },
+                ErrorKind::BadConversion(e),
             )
         })?;
 
@@ -134,9 +144,13 @@ where
     where
         ValueType: WritableAsDbaseField,
     {
-        self.file.file_position = self
-            .seek_to_beginning()
-            .map_err(|e| Error::new(e, self.record_index.0))?;
+        self.file.file_position = self.seek_to_beginning().map_err(|e| {
+            let field_info = &self.file.fields_info[self.field_index.0];
+            Error::from_field_error(
+                self.record_index,
+                FieldError::from_info(self.field_index, field_info, e),
+            )
+        })?;
 
         let field_info = &self.file.fields_info[self.field_index.0];
 
@@ -152,18 +166,18 @@ where
         value
             .write_as(field_info, &self.file.encoding, &mut cursor)
             .map_err(|e| {
-                Error::new(
-                    FieldIOError::new(e, Some(field_info.clone())),
-                    self.record_index.0,
+                Error::from_field_error(
+                    self.record_index,
+                    FieldError::from_info(self.field_index, field_info, e),
                 )
             })?;
 
         let buffer = cursor.into_inner();
 
         self.file.inner.write_all(buffer).map_err(|e| {
-            Error::new(
-                FieldIOError::new(ErrorKind::IoError(e), Some(field_info.clone())),
-                self.record_index.0,
+            Error::from_field_error(
+                self.record_index,
+                FieldError::from_info(self.field_index, field_info, e),
             )
         })?;
 
@@ -214,11 +228,11 @@ impl<T> RecordRef<'_, T>
 where
     T: Seek,
 {
-    pub fn seek_before_deletion_flag(&mut self) -> Result<u64, FieldIOError> {
+    pub fn seek_before_deletion_flag(&mut self) -> Result<u64, ErrorKind> {
         self.file
             .inner
             .seek(SeekFrom::Start(self.position_in_source()))
-            .map_err(|e| FieldIOError::new(ErrorKind::IoError(e), None))
+            .map_err(ErrorKind::IoError)
     }
 }
 
@@ -242,10 +256,10 @@ where
     ///
     /// Shortcut for `.field(index).unwrap().read().unwrap();`
     pub fn read_field(&mut self, field_index: FieldIndex) -> Result<FieldValue, Error> {
-        let record_index = self.index.0;
+        let record_index = self.index;
         let mut field = self
             .field(field_index)
-            .ok_or_else(|| Error::new(FieldIOError::end_of_record(), record_index))?;
+            .ok_or_else(|| Error::from_field_error(record_index, FieldError::end_of_record()))?;
         field.read()
     }
 
@@ -256,10 +270,10 @@ where
     where
         ValueType: TryFrom<FieldValue, Error = FieldConversionError>,
     {
-        let record_index = self.index.0;
+        let record_index = self.index;
         let mut field = self
             .field(field_index)
-            .ok_or_else(|| Error::new(FieldIOError::end_of_record(), record_index))?;
+            .ok_or_else(|| Error::from_field_error(record_index, FieldError::end_of_record()))?;
         field.read_as()
     }
 
@@ -280,14 +294,15 @@ where
             .set_position(DELETION_FLAG_SIZE as u64);
         let mut field_iterator = FieldIterator {
             source: &mut self.file.record_data_buffer,
-            fields_info: self.file.fields_info.iter().peekable(),
+            fields_info: &self.file.fields_info.inner,
+            next_index: FieldIndex(0),
             memo_reader: &mut self.file.memo_reader,
             field_data_buffer: &mut self.file.field_data_buffer,
             encoding: &self.file.encoding,
             options: self.file.options,
         };
 
-        R::read_using(&mut field_iterator).map_err(|error| Error::new(error, self.index.0))
+        R::read_using(&mut field_iterator).map_err(|err| Error::from_field_error(self.index, err))
     }
 }
 
@@ -306,10 +321,10 @@ where
     where
         ValueType: WritableAsDbaseField,
     {
-        let record_index = self.index.0;
+        let record_index = self.index;
         let mut field = self
             .field(field_index)
-            .ok_or_else(|| Error::new(FieldIOError::end_of_record(), record_index))?;
+            .ok_or_else(|| Error::from_field_error(record_index, FieldError::end_of_record()))?;
         field.write(value)
     }
 
@@ -325,22 +340,23 @@ where
 
         let mut field_writer = FieldWriter {
             dst: &mut self.file.record_data_buffer,
-            fields_info: self.file.fields_info.iter().peekable(),
+            fields_info: &self.file.fields_info.inner,
+            next_index: FieldIndex(0),
             field_buffer: &mut Cursor::new(&mut self.file.field_data_buffer),
             encoding: &self.file.encoding,
         };
 
         record
             .write_using(&mut field_writer)
-            .map_err(|error| Error::new(error, self.index.0))?;
+            .map_err(|error| Error::from_field_error(self.index, error))?;
 
         self.seek_before_deletion_flag()
-            .map_err(|error| Error::new(error, self.index.0))?;
+            .map_err(|error| Error::deletion_flag(self.index, error))?;
 
         self.file
             .inner
             .write_all(self.file.record_data_buffer.get_ref())
-            .map_err(|error| Error::io_error(error, self.index.0))?;
+            .map_err(|error| Error::record(self.index, error))?;
 
         // We don't need to update the file's inner position as we re-wrote the whole record
         debug_assert_eq!(
@@ -461,11 +477,11 @@ pub(crate) fn open_dbase<T>(
 where
     T: Read + Seek,
 {
-    let mut header = Header::read_from(source).map_err(|error| Error::io_error(error, 0))?;
+    let mut header = Header::read_from(source).map_err(Error::header)?;
 
     let offset = if header.file_type.is_visual_fox_pro() {
         if BACKLINK_SIZE > header.offset_to_first_record {
-            return Err(Error::pre_fields(ErrorKind::InvalidFile(
+            return Err(Error::header(ErrorKind::InvalidFile(
                 "File is invalid (BACKLINK_SIZE too big)",
             )));
         }
@@ -478,7 +494,7 @@ where
         .checked_sub(Header::SIZE + size_of::<u8>())
         .map(|v| v / FieldInfo::SIZE)
         .ok_or_else(|| {
-            Error::pre_fields(ErrorKind::InvalidFile(
+            Error::header(ErrorKind::InvalidFile(
                 "offset to first record is before end of header",
             ))
         })?;
@@ -489,25 +505,19 @@ where
         None => header
             .code_page_mark
             .to_encoding()
-            .ok_or_else(|| Error::pre_fields(UnsupportedCodePage(header.code_page_mark)))?,
+            .ok_or_else(|| Error::header(UnsupportedCodePage(header.code_page_mark)))?,
     };
 
     let fields_info =
-        FieldsInfo::read_from(source, num_fields, &encoding).map_err(|error| Error {
-            record_num: 0,
-            field: None,
-            kind: error,
-        })?;
+        FieldsInfo::read_from(source, num_fields, &encoding).map_err(Error::header)?;
 
     // We chose to not check the content of this value, ideally it should be
     // TERMINATOR_VALUE
-    let _terminator = source
-        .read_u8()
-        .map_err(|error| Error::io_error(error, 0))?;
+    let _terminator = source.read_u8().map_err(Error::header)?;
 
     source
         .seek(SeekFrom::Start(u64::from(header.offset_to_first_record)))
-        .map_err(|error| Error::io_error(error, 0))?;
+        .map_err(Error::header)?;
 
     let record_size: usize = DELETION_FLAG_SIZE + fields_info.size_of_all_fields();
     // Some file seems not to include the DELETION_FLAG_SIZE into the record size,
@@ -599,12 +609,12 @@ impl<T: Read + Seek> File<T> {
             self.file_position = self
                 .inner
                 .seek(SeekFrom::Start(start_of_record_pos))
-                .map_err(|e| Error::io_error(e, record_index.0))?;
+                .map_err(|e| Error::record(record_index, e))?;
         }
 
         self.inner
             .read_exact(self.record_data_buffer.get_mut())
-            .map_err(|e| Error::io_error(e, record_index.0))?;
+            .map_err(|e| Error::record(record_index, e))?;
         self.file_position += self.record_data_buffer.get_mut().len() as u64;
         Ok(true)
     }
@@ -654,11 +664,10 @@ impl<T: Write + Seek> File<T> {
             .overflowing_add(records.len() as u32)
             .1
         {
-            return Err(Error {
-                record_num: self.num_records(),
-                field: None,
-                kind: ErrorKind::Message("Too many records (u32 overflow)".to_string()),
-            });
+            return Err(Error::record(
+                RecordIndex(self.num_records()),
+                ErrorKind::Message("Too many records (u32 overflow)".to_string()),
+            ));
         }
 
         let end_of_last_record = self.header.offset_to_first_record as u64
@@ -666,31 +675,32 @@ impl<T: Write + Seek> File<T> {
 
         self.inner
             .seek(SeekFrom::Start(end_of_last_record))
-            .map_err(|error| Error::io_error(error, self.num_records()))?;
+            .map_err(|error| Error::record(RecordIndex(self.num_records()), error))?;
 
         for record in records {
             let current_record_index = self.header.num_records + 1;
 
             let mut field_writer = FieldWriter {
                 dst: &mut self.inner,
-                fields_info: self.fields_info.iter().peekable(),
+                fields_info: &self.fields_info.inner,
+                next_index: FieldIndex(0),
                 field_buffer: &mut Cursor::new(&mut self.field_data_buffer),
                 encoding: &self.encoding,
             };
 
-            field_writer
-                .write_deletion_flag()
-                .map_err(|error| Error::io_error(error, current_record_index as usize))?;
+            field_writer.write_deletion_flag().map_err(|error| {
+                Error::deletion_flag(RecordIndex(current_record_index as usize), error)
+            })?;
 
-            record
-                .write_using(&mut field_writer)
-                .map_err(|error| Error::new(error, current_record_index as usize))?;
+            record.write_using(&mut field_writer).map_err(|error| {
+                Error::from_field_error(RecordIndex(current_record_index as usize), error)
+            })?;
 
             self.header.num_records = current_record_index;
         }
 
         self.sync_all()
-            .map_err(|error| Error::io_error(error, self.num_records()))?;
+            .map_err(|error| Error::record(RecordIndex(self.num_records()), error))?;
 
         Ok(())
     }
@@ -709,16 +719,14 @@ impl File<bufrw::BufReaderWriter<std::fs::File>> {
         path: P,
         options: std::fs::OpenOptions,
     ) -> Result<Self, Error> {
-        let file = options
-            .open(path)
-            .map_err(|error| Error::io_error(error, 0))?;
+        let file = options.open(path).map_err(Error::header)?;
         let source = bufrw::BufReaderWriter::new(file);
         File::open(source)
     }
 
     /// Opens an existing dBase file in read only mode
     pub fn open_read_only<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let file = std::fs::File::open(path.as_ref()).map_err(|error| Error::io_error(error, 0))?;
+        let file = std::fs::File::open(path.as_ref()).map_err(Error::header)?;
 
         let mut file = File::open(bufrw::BufReaderWriter::new(file))?;
         if file.fields_info.at_least_one_field_is_memo() {
@@ -727,14 +735,11 @@ impl File<bufrw::BufReaderWriter<std::fs::File>> {
             if let Some(mt) = memo_type {
                 let memo_path = p.with_extension(mt.extension());
 
-                let memo_file = std::fs::File::open(memo_path).map_err(|error| Error {
-                    record_num: 0,
-                    field: None,
-                    kind: ErrorKind::ErrorOpeningMemoFile(error),
-                })?;
+                let memo_file = std::fs::File::open(memo_path)
+                    .map_err(|error| Error::header(ErrorKind::ErrorOpeningMemoFile(error)))?;
 
                 let memo_reader = MemoReader::new(mt, bufrw::BufReaderWriter::new(memo_file))
-                    .map_err(|error| Error::io_error(error, 0))?;
+                    .map_err(Error::header)?;
 
                 file.memo_reader = Some(memo_reader);
             }
@@ -764,7 +769,7 @@ impl File<bufrw::BufReaderWriter<std::fs::File>> {
 
     /// This function will create a file if it does not exist, and will truncate it if it does.
     pub fn create<P: AsRef<Path>>(path: P, table_info: TableInfo) -> Result<Self, Error> {
-        let file = std::fs::File::create(path).map_err(|error| Error::io_error(error, 0))?;
+        let file = std::fs::File::create(path).map_err(Error::header)?;
 
         File::create_new(bufrw::BufReaderWriter::new(file), table_info)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 //! }
 //!
 //! impl dbase::ReadableRecord for StationRecord {
-//!     fn read_using<R1, R2>(field_iterator: &mut dbase::FieldIterator<R1, R2>) -> Result<Self, dbase::FieldIOError>
+//!     fn read_using<R1, R2>(field_iterator: &mut dbase::FieldIterator<R1, R2>) -> Result<Self, dbase::FieldError>
 //!          where R1: Read + Seek,
 //!                R2: Read + Seek,
 //!    {
@@ -218,7 +218,7 @@
 //! ```
 //!
 //!```
-//! use dbase::{TableWriterBuilder, FieldName, WritableRecord, FieldWriter, FieldIOError, Encoding};
+//! use dbase::{TableWriterBuilder, FieldName, WritableRecord, FieldWriter, FieldError, Encoding};
 //! use std::convert::TryFrom;
 //! use std::io::{Cursor, Write};
 //!
@@ -228,7 +228,7 @@
 //! }
 //!
 //! impl WritableRecord for User {
-//!     fn write_using<'a, W>(&self, field_writer: &mut FieldWriter<'a, W>) -> Result<(), FieldIOError>
+//!     fn write_using<'a, W>(&self, field_writer: &mut FieldWriter<'a, W>) -> Result<(), FieldError>
 //!         where W: Write
 //!     {
 //!         field_writer.write_next_field_value(&self.nick_name)?;
@@ -327,7 +327,7 @@ pub use file::{BufReadWriteFile, FieldIndex, FieldRef, File, RecordIndex, Record
 #[cfg(feature = "datafusion")]
 pub use crate::datafusion::{DbaseDataSource, DbaseTableFactory};
 pub use crate::encoding::{Encoding, Unicode, UnicodeLossy};
-pub use crate::error::{Error, ErrorKind, FieldIOError};
+pub use crate::error::{Error, ErrorKind, FieldError};
 pub use crate::field::types::{
     Date, DateParseError, DateTime, FieldType, FieldValue, Time, TrimOption,
 };
@@ -376,7 +376,7 @@ macro_rules! dbase_record {
         }
 
         impl dbase::ReadableRecord for $name {
-            fn read_using<Source, MemoSource>(field_iterator: &mut dbase::FieldIterator<Source, MemoSource>) -> Result<Self, dbase::FieldIOError>
+            fn read_using<Source, MemoSource>(field_iterator: &mut dbase::FieldIterator<Source, MemoSource>) -> Result<Self, dbase::FieldError>
                 where Source: std::io::Read + std::io::Seek,
                       MemoSource: std::io::Read + std::io::Seek
                 {
@@ -391,7 +391,7 @@ macro_rules! dbase_record {
         }
 
        impl dbase::WritableRecord for $name {
-           fn write_using<'a, W>(&self, field_writer: &mut dbase::FieldWriter<'a, W>) -> Result<(), dbase::FieldIOError>
+           fn write_using<'a, W>(&self, field_writer: &mut dbase::FieldWriter<'a, W>) -> Result<(), dbase::FieldError>
            where W: std::io::Write,
            {
                 $(

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -7,12 +7,12 @@ use std::iter::FusedIterator;
 use std::path::Path;
 
 use crate::encoding::DynEncoding;
-use crate::error::{Error, ErrorKind, FieldIOError};
+use crate::error::{Error, ErrorKind, FieldError};
 use crate::field::types::{FieldType, FieldValue, TrimOption};
 use crate::field::{DeletionFlag, FieldInfo};
 use crate::header::Header;
 use crate::memo::{MemoFileType, MemoReader};
-use crate::{FieldConversionError, Record, file};
+use crate::{FieldConversionError, FieldIndex, Record, RecordIndex, file};
 
 /// Value of the byte between the last RecordFieldInfo and the first record
 pub(crate) const TERMINATOR_VALUE: u8 = 0x0D;
@@ -31,7 +31,7 @@ pub trait ReadableRecord: Sized {
     /// using values read from the `FieldIterator'
     fn read_using<Source, MemoSource>(
         field_iterator: &mut FieldIterator<Source, MemoSource>,
-    ) -> Result<Self, FieldIOError>
+    ) -> Result<Self, FieldError>
     where
         Source: Read + Seek,
         MemoSource: Read + Seek;
@@ -132,9 +132,7 @@ impl ReaderBuilder {
         P: AsRef<Path>,
     {
         let p = path.as_ref();
-        let mut bufreader = File::open(p)
-            .map(BufReader::new)
-            .map_err(|error| Error::io_error(error, 0))?;
+        let mut bufreader = File::open(p).map(BufReader::new).map_err(Error::header)?;
 
         let (header, fields_info, encoding) = file::open_dbase(&mut bufreader, self.encoding)?;
 
@@ -151,16 +149,11 @@ impl ReaderBuilder {
                     MemoFileType::FoxBaseMemo => p.with_extension("fpt"),
                 };
 
-                let memo_file = File::open(memo_path).map_err(|error| Error {
-                    record_num: 0,
-                    field: None,
-                    kind: ErrorKind::ErrorOpeningMemoFile(error),
-                })?;
+                let memo_file = File::open(memo_path)
+                    .map_err(|error| Error::header(ErrorKind::ErrorOpeningMemoFile(error)))?;
 
-                memo_reader = Some(
-                    MemoReader::new(mt, BufReader::new(memo_file))
-                        .map_err(|error| Error::io_error(error, 0))?,
-                );
+                memo_reader =
+                    Some(MemoReader::new(mt, BufReader::new(memo_file)).map_err(Error::header)?);
             }
         }
 
@@ -193,13 +186,15 @@ impl ReaderBuilder {
         T: Read + Seek,
     {
         let (header, fields_info, encoding) = file::open_dbase(&mut source, self.encoding)?;
-
         let memo_reader = if let Some(memo_source) = memo_source {
-            let memo_type = header
-                .file_type
-                .supported_memo_type()
-                .unwrap_or(MemoFileType::FoxBaseMemo); // or pick a sensible default
-            Some(MemoReader::new(memo_type, memo_source).map_err(|e| Error::io_error(e, 0))?)
+            let memo_type = header.file_type.supported_memo_type();
+            if let Some(mt) = memo_type {
+                let memo_reader = MemoReader::new(mt, memo_source).map_err(Error::header)?;
+
+                Some(memo_reader)
+            } else {
+                None
+            }
         } else {
             None
         };
@@ -279,7 +274,7 @@ impl<T: Read + Seek> Reader<T> {
         RecordIterator {
             reader: self,
             record_type: std::marker::PhantomData,
-            current_record: 0,
+            current_record: RecordIndex(0),
             record_data_buffer: std::io::Cursor::new(vec![0u8; record_size]),
             field_data_buffer: [0u8; 255],
         }
@@ -321,7 +316,7 @@ impl<T: Read + Seek> Reader<T> {
             + (index * self.header.size_of_record as usize);
         self.source
             .seek(SeekFrom::Start(offset as u64))
-            .map_err(|err| Error::io_error(err, 0))?;
+            .map_err(|err| Error::record(RecordIndex(index), err))?;
         Ok(())
     }
 
@@ -398,7 +393,9 @@ pub struct FieldIterator<'a, Source, MemoSource> {
     /// The source from where we read the data
     pub(crate) source: &'a mut Source,
     /// The fields that make the records
-    pub(crate) fields_info: std::iter::Peekable<std::slice::Iter<'a, FieldInfo>>,
+    pub(crate) fields_info: &'a [FieldInfo],
+    /// The next field index that will be read
+    pub(crate) next_index: FieldIndex,
     /// The source where the Memo field data is read
     pub(crate) memo_reader: &'a mut Option<MemoReader<MemoSource>>,
     /// Buffer where field data is stored
@@ -410,36 +407,26 @@ pub struct FieldIterator<'a, Source, MemoSource> {
 
 impl<'a, Source: Read + Seek, MemoSource: Read + Seek> FieldIterator<'a, Source, MemoSource> {
     /// Reads the next field and returns its name and value
-    pub fn read_next_field_impl(&mut self) -> Result<(&'a FieldInfo, FieldValue), FieldIOError> {
-        let field_info = self
-            .fields_info
-            .next()
-            .ok_or_else(FieldIOError::end_of_record)?;
-        Ok((field_info, self.read_field(field_info)?))
-    }
-
-    /// Reads the next field and returns its name and value
-    pub fn read_next_field(&mut self) -> Result<NamedValue<'a, FieldValue>, FieldIOError> {
-        self.read_next_field_impl()
-            .map(|(field_info, field_value)| NamedValue {
-                name: field_info.name(),
-                value: field_value,
-            })
+    pub fn read_next_field(&mut self) -> Result<NamedValue<'a, FieldValue>, FieldError> {
+        self.read_next_field_x().map(|(value, _, info)| NamedValue {
+            name: &info.name,
+            value,
+        })
     }
 
     /// Reads the next field and tries to convert into the requested type
     /// using [TryFrom]
-    pub fn read_next_field_as<F>(&mut self) -> Result<NamedValue<'a, F>, FieldIOError>
+    pub fn read_next_field_as<F>(&mut self) -> Result<NamedValue<'a, F>, FieldError>
     where
         F: TryFrom<FieldValue, Error = FieldConversionError>,
     {
-        self.read_next_field_impl()
-            .and_then(|(field_info, field_value)| match F::try_from(field_value) {
+        self.read_next_field_x()
+            .and_then(|(value, index, info)| match F::try_from(value) {
                 Ok(v) => Ok(NamedValue {
-                    name: field_info.name(),
+                    name: &info.name,
                     value: v,
                 }),
-                Err(e) => Err(FieldIOError::new(e.into(), Some(field_info.to_owned()))),
+                Err(err) => Err(FieldError::from_info(index, info, err)),
             })
     }
 
@@ -447,10 +434,19 @@ impl<'a, Source: Read + Seek, MemoSource: Read + Seek> FieldIterator<'a, Source,
     /// but the ones after do.
     ///
     /// Does nothing if the last field of the record was already skipped or read.
-    pub fn skip_next_field(&mut self) -> Result<(), FieldIOError> {
-        match self.fields_info.next() {
+    pub fn skip_next_field(&mut self) -> Result<(), FieldError> {
+        match self.fields_info.get(self.next_index.0) {
             None => Ok(()),
-            Some(field_info) => self.skip_field(field_info),
+            Some(field_info) => {
+                self.source
+                    .seek(SeekFrom::Current(i64::from(field_info.field_length)))
+                    .map(|_| ())
+                    .map_err(|error| FieldError::from_info(self.next_index, field_info, error))?;
+
+                self.next_index.0 += 1;
+
+                Ok(())
+            }
         }
     }
 
@@ -460,86 +456,104 @@ impl<'a, Source: Read + Seek, MemoSource: Read + Seek> FieldIterator<'a, Source,
     /// when we will start reading the next record
     ///
     /// Does nothing if the last field of the record was already skipped or read.
-    fn skip_remaining_fields(&mut self) -> Result<(), FieldIOError> {
-        while let Some(field_info) = self.fields_info.next() {
-            self.skip_field(field_info)?;
+    fn skip_remaining_fields(&mut self) -> Result<(), FieldError> {
+        let Some(size_to_skip) = self
+            .fields_info
+            .get(self.next_index.0..)
+            .map(|fields| fields.iter().map(|f| i64::from(f.field_length)).sum())
+        else {
+            return Ok(());
+        };
+
+        if size_to_skip == 0 {
+            return Ok(());
         }
+
+        self.source
+            .seek(SeekFrom::Current(size_to_skip))
+            .map_err(|error| {
+                FieldError::from_info(self.next_index, &self.fields_info[self.next_index.0], error)
+            })?;
+
+        self.next_index.0 = self.fields_info.len() + 1;
         Ok(())
     }
 
     /// Reads the raw bytes of the next field without doing any filtering or trimming
     #[cfg(feature = "serde")]
-    pub(crate) fn read_next_field_raw(&mut self) -> Result<Vec<u8>, FieldIOError> {
+    pub(crate) fn read_next_field_raw(&mut self) -> Result<Vec<u8>, FieldError> {
         let field_info = self
             .fields_info
-            .next()
-            .ok_or(FieldIOError::end_of_record())?;
+            .get(self.next_index.0)
+            .ok_or_else(FieldError::end_of_record)?;
         let mut buf = vec![0u8; field_info.field_length as usize];
-        self.source.read_exact(&mut buf).map_err(|error| {
-            FieldIOError::new(ErrorKind::IoError(error), Some(field_info.to_owned()))
-        })?;
+        self.source
+            .read_exact(&mut buf)
+            .map_err(|e| FieldError::from_info(self.next_index, field_info, e))?;
+        self.next_index.0 += 1;
         Ok(buf)
     }
 
     #[cfg(feature = "serde")]
-    pub(crate) fn peek_next_field(&mut self) -> Result<NamedValue<'a, FieldValue>, FieldIOError> {
-        let field_info = *self.fields_info.peek().ok_or(FieldIOError {
-            field: None,
-            kind: ErrorKind::EndOfRecord,
-        })?;
-        let value = self.read_field(field_info)?;
+    pub(crate) fn peek_next_field(&mut self) -> Result<NamedValue<'a, FieldValue>, FieldError> {
+        let field_info = self
+            .fields_info
+            .get(self.next_index.0)
+            .ok_or_else(FieldError::end_of_record)?;
+        let field_data_buffer = &mut self.field_data_buffer[..field_info.length() as usize];
+        self.source
+            .read_exact(field_data_buffer)
+            .map_err(|e| FieldError::from_info(self.next_index, field_info, e))?;
+        let value = FieldValue::read_from(
+            field_data_buffer,
+            self.memo_reader,
+            field_info,
+            self.encoding,
+            self.options.character_trim,
+        )
+        .map_err(|e| FieldError::from_info(self.next_index, field_info, e))?;
         self.source
             .seek(SeekFrom::Current(-i64::from(field_info.field_length)))
-            .map_err(|error| {
-                FieldIOError::new(ErrorKind::IoError(error), Some(field_info.to_owned()))
-            })?;
-
+            .map_err(|e| FieldError::from_info(self.next_index, field_info, e))?;
         Ok(NamedValue {
             name: field_info.name(),
             value,
         })
     }
 
-    /// Advance the source to skip the field
-    fn skip_field(&mut self, field_info: &FieldInfo) -> Result<(), FieldIOError> {
-        self.source
-            .seek(SeekFrom::Current(i64::from(field_info.field_length)))
-            .map_err(|error| {
-                FieldIOError::new(ErrorKind::IoError(error), Some(field_info.to_owned()))
-            })?;
-        Ok(())
-    }
+    fn read_next_field_x(&mut self) -> Result<(FieldValue, FieldIndex, &'a FieldInfo), FieldError> {
+        let field_info = self
+            .fields_info
+            .get(self.next_index.0)
+            .ok_or(FieldError::end_of_record())?;
 
-    /// read the next field using the given info
-    fn read_field(&mut self, field_info: &'a FieldInfo) -> Result<FieldValue, FieldIOError> {
         let field_data_buffer = &mut self.field_data_buffer[..field_info.length() as usize];
         self.source
             .read_exact(field_data_buffer)
-            .map_err(|err| FieldIOError::new(err.into(), Some(field_info.clone())))?;
-        match FieldValue::read_from(
+            .map_err(|err| FieldError::from_info(self.next_index, field_info, err))?;
+
+        let result = FieldValue::read_from(
             field_data_buffer,
             self.memo_reader,
             field_info,
             self.encoding,
             self.options.character_trim,
-        ) {
-            Ok(value) => Ok(value),
-            Err(kind) => Err(FieldIOError {
-                field: Some(field_info.clone()),
-                kind,
-            }),
-        }
+        )
+        .map(|value| (value, self.next_index, field_info))
+        .map_err(|err| FieldError::from_info(self.next_index, field_info, err));
+        self.next_index.0 += 1;
+        result
     }
 }
 
 impl<'a, Source: Read + Seek, MemoSource: Read + Seek> Iterator
     for FieldIterator<'a, Source, MemoSource>
 {
-    type Item = Result<NamedValue<'a, FieldValue>, FieldIOError>;
+    type Item = Result<NamedValue<'a, FieldValue>, FieldError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.read_next_field() {
-            Err(error) => match error.kind() {
+            Err(error) => match error.kind {
                 ErrorKind::EndOfRecord => None,
                 _ => Some(Err(error)),
             },
@@ -557,7 +571,7 @@ impl<Source: Read + Seek, MemoSource: Read + Seek> FusedIterator
 pub struct RecordIterator<'a, T, R> {
     reader: &'a mut Reader<T>,
     record_type: std::marker::PhantomData<R>,
-    current_record: u32,
+    current_record: RecordIndex,
     record_data_buffer: std::io::Cursor<Vec<u8>>,
     /// Non-Memo field length is stored on a u8,
     /// so fields cannot exceed 255 bytes
@@ -569,21 +583,24 @@ impl<T: Read + Seek, R: ReadableRecord> Iterator for RecordIterator<'_, T, R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            return if self.current_record >= self.reader.header.num_records {
+            return if self.current_record.0 >= self.reader.header.num_records as usize {
                 None
             } else {
                 let deletion_flag = match DeletionFlag::read_from(&mut self.reader.source) {
                     Ok(flag) => flag,
-                    Err(e) => return Some(Err(Error::io_error(e, self.current_record as usize))),
+                    Err(e) => {
+                        return Some(Err(Error::deletion_flag(self.current_record, e)));
+                    }
                 };
 
                 if deletion_flag == DeletionFlag::Deleted {
+                    // Skip the whole record
                     if let Err(e) = self.reader.source.seek(SeekFrom::Current(
                         self.record_data_buffer.get_ref().len() as i64,
                     )) {
-                        return Some(Err(Error::io_error(e, self.current_record as usize)));
+                        return Some(Err(Error::record(self.current_record, e)));
                     }
-                    self.current_record += 1;
+                    self.current_record.0 += 1;
                     continue;
                 }
 
@@ -592,13 +609,14 @@ impl<T: Read + Seek, R: ReadableRecord> Iterator for RecordIterator<'_, T, R> {
                     .source
                     .read_exact(self.record_data_buffer.get_mut())
                 {
-                    return Some(Err(Error::io_error(e, self.current_record as usize)));
+                    return Some(Err(Error::record(self.current_record, e)));
                 }
                 self.record_data_buffer.set_position(0);
 
                 let mut iter = FieldIterator {
                     source: &mut self.record_data_buffer,
-                    fields_info: self.reader.fields_info.iter().peekable(),
+                    fields_info: &self.reader.fields_info,
+                    next_index: FieldIndex(0),
                     memo_reader: &mut self.reader.memo_reader,
                     field_data_buffer: &mut self.field_data_buffer,
                     encoding: &self.reader.encoding,
@@ -607,8 +625,8 @@ impl<T: Read + Seek, R: ReadableRecord> Iterator for RecordIterator<'_, T, R> {
 
                 let record = R::read_using(&mut iter)
                     .and_then(|record| iter.skip_remaining_fields().and(Ok(record)))
-                    .map_err(|error| Error::new(error, self.current_record as usize));
-                self.current_record += 1;
+                    .map_err(|error| Error::from_field_error(self.current_record, error));
+                self.current_record.0 += 1;
                 Some(record)
             };
         }

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,4 +1,4 @@
-use crate::{FieldIOError, FieldIterator, FieldValue, NamedValue, ReadableRecord};
+use crate::{FieldError, FieldIterator, FieldValue, NamedValue, ReadableRecord};
 use std::collections::HashMap;
 use std::collections::hash_map::RandomState;
 use std::io::{Read, Seek};
@@ -13,7 +13,7 @@ pub struct Record {
 impl ReadableRecord for Record {
     fn read_using<Source, MemoSource>(
         field_iterator: &mut FieldIterator<Source, MemoSource>,
-    ) -> Result<Self, FieldIOError>
+    ) -> Result<Self, FieldError>
     where
         Source: Read + Seek,
         MemoSource: Read + Seek,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use crate::field::types::FieldType;
 use crate::writing::FieldWriter;
-use crate::{Date, FieldIOError};
+use crate::{Date, FieldError};
 use crate::{ErrorKind, WritableRecord};
 
 impl<T> WritableRecord for T
@@ -13,14 +13,14 @@ where
     fn write_using<'a, W: Write>(
         &self,
         field_writer: &mut FieldWriter<'a, W>,
-    ) -> Result<(), FieldIOError> {
+    ) -> Result<(), FieldError> {
         self.serialize(field_writer)
     }
 }
 
 impl<'a, W: Write> Serializer for &mut FieldWriter<'a, W> {
     type Ok = ();
-    type Error = FieldIOError;
+    type Error = FieldError;
     type SerializeSeq = Self;
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
@@ -46,7 +46,7 @@ impl<'a, W: Write> Serializer for &mut FieldWriter<'a, W> {
     }
 
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        let v: i32 = v.try_into().map_err(|_| -> FieldIOError {
+        let v: i32 = v.try_into().map_err(|_| -> FieldError {
             serde::ser::Error::custom("i64 value out of range for dBase integer field")
         })?;
         self.write_next_field_value(&v)
@@ -61,14 +61,14 @@ impl<'a, W: Write> Serializer for &mut FieldWriter<'a, W> {
     }
 
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        let v: i32 = v.try_into().map_err(|_| -> FieldIOError {
+        let v: i32 = v.try_into().map_err(|_| -> FieldError {
             serde::ser::Error::custom("u32 value out of range for dBase integer field")
         })?;
         self.write_next_field_value(&v)
     }
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        let v: i32 = v.try_into().map_err(|_| -> FieldIOError {
+        let v: i32 = v.try_into().map_err(|_| -> FieldError {
             serde::ser::Error::custom("u64 value out of range for dBase integer field")
         })?;
         self.write_next_field_value(&v)
@@ -97,20 +97,21 @@ impl<'a, W: Write> Serializer for &mut FieldWriter<'a, W> {
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        if let Some(field_info) = self.fields_info.peek() {
+        if let Some(field_info) = self.fields_info.get(self.next_index.0) {
             match field_info.field_type {
                 FieldType::Character => self.write_next_field_value::<Option<String>>(&None),
                 FieldType::Numeric => self.write_next_field_value::<Option<f64>>(&None),
                 FieldType::Float => self.write_next_field_value::<Option<f32>>(&None),
                 FieldType::Date => self.write_next_field_value::<Option<Date>>(&None),
                 FieldType::Logical => self.write_next_field_value::<Option<bool>>(&None),
-                _ => Err(FieldIOError::new(
+                _ => Err(FieldError::from_info(
+                    self.next_index,
+                    field_info,
                     ErrorKind::Message("This field cannot store None values".to_string()),
-                    Some((*field_info).to_owned()),
                 )),
             }
         } else {
-            Err(FieldIOError::end_of_record())
+            Err(FieldError::end_of_record())
         }
     }
 
@@ -233,7 +234,7 @@ impl<'a, W: Write> Serializer for &mut FieldWriter<'a, W> {
 
 impl<'a, W: Write> serde::ser::SerializeStructVariant for &mut FieldWriter<'a, W> {
     type Ok = ();
-    type Error = FieldIOError;
+    type Error = FieldError;
 
     fn serialize_field<T>(&mut self, _key: &'static str, _value: &T) -> Result<(), Self::Error>
     where
@@ -253,7 +254,7 @@ impl<'a, W: Write> serde::ser::SerializeStructVariant for &mut FieldWriter<'a, W
 
 impl<'a, W: Write> serde::ser::SerializeStruct for &mut FieldWriter<'a, W> {
     type Ok = ();
-    type Error = FieldIOError;
+    type Error = FieldError;
 
     fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
     where
@@ -269,7 +270,7 @@ impl<'a, W: Write> serde::ser::SerializeStruct for &mut FieldWriter<'a, W> {
 
 impl<'a, W: Write> serde::ser::SerializeSeq for &mut FieldWriter<'a, W> {
     type Ok = ();
-    type Error = FieldIOError;
+    type Error = FieldError;
 
     fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
@@ -285,7 +286,7 @@ impl<'a, W: Write> serde::ser::SerializeSeq for &mut FieldWriter<'a, W> {
 
 impl<'a, W: Write> serde::ser::SerializeMap for &mut FieldWriter<'a, W> {
     type Ok = ();
-    type Error = FieldIOError;
+    type Error = FieldError;
 
     fn serialize_key<T>(&mut self, _key: &T) -> Result<(), Self::Error>
     where
@@ -308,7 +309,7 @@ impl<'a, W: Write> serde::ser::SerializeMap for &mut FieldWriter<'a, W> {
 
 impl<'a, W: Write> serde::ser::SerializeTupleVariant for &mut FieldWriter<'a, W> {
     type Ok = ();
-    type Error = FieldIOError;
+    type Error = FieldError;
 
     fn serialize_field<T>(&mut self, _value: &T) -> Result<(), Self::Error>
     where
@@ -328,7 +329,7 @@ impl<'a, W: Write> serde::ser::SerializeTupleVariant for &mut FieldWriter<'a, W>
 
 impl<'a, W: Write> serde::ser::SerializeTupleStruct for &mut FieldWriter<'a, W> {
     type Ok = ();
-    type Error = FieldIOError;
+    type Error = FieldError;
 
     fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
@@ -344,7 +345,7 @@ impl<'a, W: Write> serde::ser::SerializeTupleStruct for &mut FieldWriter<'a, W> 
 
 impl<'a, W: Write> serde::ser::SerializeTuple for &mut FieldWriter<'a, W> {
     type Ok = ();
-    type Error = FieldIOError;
+    type Error = FieldError;
 
     fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
@@ -358,10 +359,10 @@ impl<'a, W: Write> serde::ser::SerializeTuple for &mut FieldWriter<'a, W> {
     }
 }
 
-impl serde::ser::Error for FieldIOError {
+impl serde::ser::Error for FieldError {
     fn custom<T: std::fmt::Display>(msg: T) -> Self {
         Self {
-            field: None,
+            context: None,
             kind: ErrorKind::Message(msg.to_string()),
         }
     }

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -10,7 +10,9 @@ use crate::field::{DeletionFlag, FieldInfo, FieldName, types::FieldType};
 use crate::header::Header;
 use crate::reading::TERMINATOR_VALUE;
 use crate::reading::{BACKLINK_SIZE, TableInfo};
-use crate::{Encoding, Error, ErrorKind, FieldIOError, Record, UnicodeLossy};
+use crate::{
+    Encoding, Error, ErrorKind, FieldError, FieldIndex, Record, RecordIndex, UnicodeLossy,
+};
 
 /// A dbase file ends with this byte
 const FILE_TERMINATOR: u8 = 0x1A;
@@ -23,23 +25,18 @@ pub(crate) fn write_header_parts<W>(
 where
     W: Write,
 {
-    header
-        .write_to(dst)
-        .map_err(|error| Error::io_error(error, 0))?;
+    header.write_to(dst).map_err(Error::header)?;
 
     for record_info in fields_info.iter() {
-        record_info
-            .write_to(dst)
-            .map_err(|error| Error::io_error(error, 0))?;
+        record_info.write_to(dst).map_err(Error::header)?;
     }
-    dst.write_u8(TERMINATOR_VALUE)
-        .map_err(|error| Error::io_error(error, 0))?;
+    dst.write_u8(TERMINATOR_VALUE).map_err(Error::header)?;
 
     // FoxPro has a backlink structure here, but there is no public spec.
     // Writing zeros is the standard approach when no .dbc is associated.
     if header.file_type.is_visual_fox_pro() {
         for _ in 0..BACKLINK_SIZE {
-            dst.write_u8(0).map_err(|error| Error::io_error(error, 0))?;
+            dst.write_u8(0).map_err(Error::header)?;
         }
     }
 
@@ -273,7 +270,7 @@ impl TableWriterBuilder {
         self,
         path: P,
     ) -> Result<TableWriter<BufWriter<File>>, Error> {
-        let file = File::create(path).map_err(|err| Error::io_error(err, 0))?;
+        let file = File::create(path).map_err(Error::header)?;
         let dst = BufWriter::new(file);
         Ok(self.build_with_dest(dst))
     }
@@ -338,21 +335,22 @@ pub trait WritableRecord {
     fn write_using<W: Write>(
         &self,
         field_writer: &mut FieldWriter<'_, W>,
-    ) -> Result<(), FieldIOError>;
+    ) -> Result<(), FieldError>;
 }
 
 impl WritableRecord for Record {
     fn write_using<W: Write>(
         &self,
         field_writer: &mut FieldWriter<'_, W>,
-    ) -> Result<(), FieldIOError> {
+    ) -> Result<(), FieldError> {
         while let Some(name) = field_writer.next_field_name() {
             let value = self.get(name).ok_or_else(|| {
-                FieldIOError::new(
+                FieldError::from_info(
+                    field_writer.next_index,
+                    &field_writer.fields_info[field_writer.next_index.0],
                     ErrorKind::Message(format!(
                         "Could not find field named '{name}' in the record map"
                     )),
-                    None,
                 )
             })?;
             field_writer.write_next_field_value(value)?;
@@ -368,7 +366,8 @@ impl WritableRecord for Record {
 /// [TableWriter](struct.TableWriter.html), otherwise an error will occur.
 pub struct FieldWriter<'a, W> {
     pub(crate) dst: &'a mut W,
-    pub(crate) fields_info: std::iter::Peekable<std::slice::Iter<'a, FieldInfo>>,
+    pub(crate) fields_info: &'a [FieldInfo],
+    pub(crate) next_index: FieldIndex,
     pub(crate) field_buffer: &'a mut Cursor<&'a mut [u8]>,
     pub(crate) encoding: &'a DynEncoding,
 }
@@ -376,7 +375,9 @@ pub struct FieldWriter<'a, W> {
 impl<'a, W: Write> FieldWriter<'a, W> {
     /// Returns the name of the next field that is expected to be written
     pub fn next_field_name(&mut self) -> Option<&'a str> {
-        self.fields_info.peek().map(|info| info.name.as_str())
+        self.fields_info
+            .get(self.next_index.0)
+            .map(|info| info.name.as_str())
     }
 
     /// Writes the given `field_value` to the record.
@@ -394,8 +395,8 @@ impl<'a, W: Write> FieldWriter<'a, W> {
     pub fn write_next_field_value<T: WritableAsDbaseField>(
         &mut self,
         field_value: &T,
-    ) -> Result<(), FieldIOError> {
-        if let Some(field_info) = self.fields_info.next() {
+    ) -> Result<(), FieldError> {
+        if let Some(field_info) = self.fields_info.get(self.next_index.0) {
             let pad_before = matches!(
                 field_info.field_type(),
                 FieldType::Numeric | FieldType::Float | FieldType::Memo
@@ -404,7 +405,7 @@ impl<'a, W: Write> FieldWriter<'a, W> {
             self.field_buffer.set_position(0);
             field_value
                 .write_as(field_info, self.encoding, &mut self.field_buffer)
-                .map_err(|kind| FieldIOError::new(kind, Some(field_info.clone())))?;
+                .map_err(|kind| FieldError::from_info(self.next_index, field_info, kind))?;
             let value_len = self.field_buffer.position() as usize;
             let bytes_to_pad = usize::from(field_info.field_length).saturating_sub(value_len);
 
@@ -418,61 +419,59 @@ impl<'a, W: Write> FieldWriter<'a, W> {
             let field_bytes = self.field_buffer.get_ref();
             self.dst
                 .write_all(&field_bytes[..write_len])
-                .map_err(|error| {
-                    FieldIOError::new(ErrorKind::IoError(error), Some(field_info.clone()))
-                })?;
+                .map_err(|kind| FieldError::from_info(self.next_index, field_info, kind))?;
 
             if bytes_to_pad > 0 && !pad_before {
                 self.write_pad(bytes_to_pad, field_info)?;
             }
 
+            self.next_index.0 += 1;
+
             Ok(())
         } else {
-            Err(FieldIOError::new(ErrorKind::TooManyFields, None))
+            Err(FieldError::without_context(ErrorKind::TooManyFields))
         }
     }
 
-    fn write_pad(&mut self, len: usize, field_info: &FieldInfo) -> Result<(), FieldIOError> {
+    fn write_pad(&mut self, len: usize, field_info: &FieldInfo) -> Result<(), FieldError> {
         for _ in 0..len {
-            write!(self.dst, " ").map_err(|error| {
-                FieldIOError::new(ErrorKind::IoError(error), Some(field_info.clone()))
-            })?;
+            write!(self.dst, " ")
+                .map_err(|error| FieldError::from_info(self.next_index, field_info, error))?;
         }
         Ok(())
     }
 
     #[cfg(feature = "serde")]
-    pub(crate) fn write_next_field_raw(&mut self, value: &[u8]) -> Result<(), FieldIOError> {
-        if let Some(field_info) = self.fields_info.next() {
+    pub(crate) fn write_next_field_raw(&mut self, value: &[u8]) -> Result<(), FieldError> {
+        if let Some(field_info) = self.fields_info.get(self.next_index.0) {
             let pad_before = matches!(
                 field_info.field_type(),
                 FieldType::Numeric | FieldType::Float | FieldType::Memo
             );
 
             if value.len() == field_info.field_length as usize {
-                self.dst.write_all(value).map_err(|error| {
-                    FieldIOError::new(ErrorKind::IoError(error), Some(field_info.clone()))
-                })?;
+                self.dst
+                    .write_all(value)
+                    .map_err(|e| FieldError::from_info(self.next_index, field_info, e))?;
             } else if value.len() < field_info.field_length as usize {
                 if pad_before {
                     self.write_pad(field_info.field_length as usize - value.len(), field_info)?;
                 }
-                self.dst.write_all(value).map_err(|error| {
-                    FieldIOError::new(ErrorKind::IoError(error), Some(field_info.clone()))
-                })?;
+                self.dst
+                    .write_all(value)
+                    .map_err(|e| FieldError::from_info(self.next_index, field_info, e))?;
                 if !pad_before {
                     self.write_pad(field_info.field_length as usize - value.len(), field_info)?;
                 }
             } else {
                 self.dst
                     .write_all(&value[..field_info.field_length as usize])
-                    .map_err(|error| {
-                        FieldIOError::new(ErrorKind::IoError(error), Some(field_info.clone()))
-                    })?;
+                    .map_err(|e| FieldError::from_info(self.next_index, field_info, e))?;
             }
+            self.next_index.0 += 1;
             Ok(())
         } else {
-            Err(FieldIOError::new(ErrorKind::EndOfRecord, None))
+            Err(FieldError::end_of_record())
         }
     }
 
@@ -481,7 +480,7 @@ impl<'a, W: Write> FieldWriter<'a, W> {
     }
 
     fn all_fields_were_written(&mut self) -> bool {
-        self.fields_info.peek().is_none()
+        self.fields_info.len() == self.next_index.0
     }
 }
 
@@ -544,11 +543,7 @@ impl<W: Write + Seek> TableWriter<W> {
 
         if self.finalized {
             let err = std::io::Error::other("Cannot write to finalized data");
-            return Err(Error {
-                record_num: current_record_num,
-                field: None,
-                kind: ErrorKind::IoError(err),
-            });
+            return Err(Error::record(RecordIndex(current_record_num), err));
         }
 
         if current_record_num == 0 {
@@ -558,25 +553,25 @@ impl<W: Write + Seek> TableWriter<W> {
 
         let mut field_writer = FieldWriter {
             dst: &mut self.dst,
-            fields_info: self.fields_info.iter().peekable(),
+            fields_info: &self.fields_info,
+            next_index: FieldIndex(0),
             field_buffer: &mut Cursor::new(&mut self.buffer),
             encoding: &self.encoding,
         };
 
         field_writer
             .write_deletion_flag()
-            .map_err(|error| Error::io_error(error, current_record_num))?;
+            .map_err(|error| Error::deletion_flag(RecordIndex(current_record_num), error))?;
 
         record
             .write_using(&mut field_writer)
-            .map_err(|error| Error::new(error, current_record_num))?;
+            .map_err(|error| Error::from_field_error(RecordIndex(current_record_num), error))?;
 
         if !field_writer.all_fields_were_written() {
-            return Err(Error {
-                record_num: current_record_num,
-                field: None,
-                kind: ErrorKind::NotEnoughFields,
-            });
+            return Err(Error::record(
+                RecordIndex(current_record_num),
+                ErrorKind::NotEnoughFields,
+            ));
         }
 
         self.header.num_records += 1;
@@ -590,7 +585,7 @@ impl<W: Write + Seek> TableWriter<W> {
     ///
     /// # Example
     /// ```
-    /// use dbase::{TableWriterBuilder, FieldName, WritableRecord, FieldWriter, ErrorKind, FieldIOError, Encoding};
+    /// use dbase::{TableWriterBuilder, FieldName, WritableRecord, FieldWriter, ErrorKind, FieldError, Encoding};
     /// use std::convert::TryFrom;
     /// use std::io::{Cursor, Write};
     ///
@@ -599,7 +594,7 @@ impl<W: Write + Seek> TableWriter<W> {
     /// }
     ///
     /// impl WritableRecord for User {
-    ///     fn write_using<'a, W>(&self,field_writer: &mut FieldWriter<'a, W>) -> Result<(), FieldIOError>
+    ///     fn write_using<'a, W>(&self,field_writer: &mut FieldWriter<'a, W>) -> Result<(), FieldError>
     ///         where W: Write {
     ///         field_writer.write_next_field_value(&self.first_name)
     ///     }
@@ -636,16 +631,17 @@ impl<W: Write + Seek> TableWriter<W> {
     /// Calling finalize on an already finalize writer is a no-op
     pub fn finalize(&mut self) -> Result<(), Error> {
         if !self.finalized {
+            let num_records = self.header.num_records as usize;
             self.dst
                 .seek(SeekFrom::Start(0))
-                .map_err(|error| Error::io_error(error, self.header.num_records as usize))?;
+                .map_err(|e| Error::record(RecordIndex(num_records), e))?;
             self.write_header()?;
             self.dst
                 .seek(SeekFrom::End(0))
-                .map_err(|error| Error::io_error(error, self.header.num_records as usize))?;
+                .map_err(|e| Error::record(RecordIndex(num_records), e))?;
             self.dst
                 .write_u8(FILE_TERMINATOR)
-                .map_err(|error| Error::io_error(error, self.header.num_records as usize))?;
+                .map_err(|e| Error::record(RecordIndex(num_records), e))?;
             self.finalized = true;
         }
         Ok(())

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -8,6 +8,23 @@ mod serde_tests {
     use dbase::{ErrorKind, FieldName, ReadableRecord, Reader, TableWriterBuilder, WritableRecord};
     use std::fmt::Debug;
 
+    fn single_char_field_reader(value: &str) -> Reader<Cursor<Vec<u8>>> {
+        #[derive(Serialize)]
+        struct Record {
+            name: String,
+        }
+        let mut dst = Cursor::new(Vec::<u8>::new());
+        TableWriterBuilder::new()
+            .add_character_field(FieldName::try_from("name").unwrap(), 50)
+            .build_with_dest(&mut dst)
+            .write_records(&[Record {
+                name: value.to_string(),
+            }])
+            .unwrap();
+        dst.set_position(0);
+        Reader::new(dst).unwrap()
+    }
+
     fn write_read_compare<R>(records: &Vec<R>, writer_builder: TableWriterBuilder)
     where
         R: WritableRecord + ReadableRecord + Debug + PartialEq,
@@ -204,5 +221,69 @@ mod serde_tests {
         }];
 
         write_read_compare(&records, writer_builder);
+    }
+
+    // `from_field_error` has two branches: when the FieldError carries a FieldContext it promotes
+    // to Error::field (field_index is Some), and when it doesn't it falls back to Error::record
+    // (field_index is None). The two tests below pin each branch.
+
+    #[test]
+    fn test_from_field_error_with_context_sets_field_index() {
+        // A type mismatch that goes through read_next_field_as produces a FieldError with
+        // context (field index + name + type), so field_index() should be Some.
+        #[derive(Debug, Deserialize)]
+        #[allow(
+            dead_code,
+            reason = "field exists only to drive serde deserialization; value is never read"
+        )]
+        struct ReadRecord {
+            name: bool, // Character field read as bool → IncompatibleType with context
+        }
+
+        let error = single_char_field_reader("test")
+            .read_as::<ReadRecord>()
+            .expect_err("expected a type mismatch error");
+
+        assert_eq!(error.record_index(), Some(dbase::RecordIndex(0)));
+        assert_eq!(error.field_index(), Some(dbase::FieldIndex(0)));
+    }
+
+    #[test]
+    fn test_from_field_error_without_context_has_no_field_index() {
+        // deserialize_any on FieldIterator returns FieldError { context: None }, so
+        // from_field_error should fall back to Error::record: record_index is Some but
+        // field_index is None.
+        #[derive(Debug)]
+        struct TriggerDeserializeAny;
+
+        impl<'de> serde::Deserialize<'de> for TriggerDeserializeAny {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                struct V;
+                impl<'de> serde::de::Visitor<'de> for V {
+                    type Value = TriggerDeserializeAny;
+                    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(f, "anything")
+                    }
+                }
+                deserializer.deserialize_any(V)
+            }
+        }
+
+        #[derive(Debug, Deserialize)]
+        #[allow(
+            dead_code,
+            reason = "field exists only to drive serde deserialization; value is never read"
+        )]
+        struct ReadRecord {
+            name: TriggerDeserializeAny,
+        }
+
+        let error = single_char_field_reader("test")
+            .read_as::<ReadRecord>()
+            .expect_err("expected IncompatibleType from deserialize_any");
+
+        assert!(matches!(error.kind(), ErrorKind::IncompatibleType));
+        assert_eq!(error.record_index(), Some(dbase::RecordIndex(0)));
+        assert_eq!(error.field_index(), None);
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,8 +3,8 @@ use dbase::dbase_record;
 use std::io::{Cursor, Read, Seek, Write};
 
 use dbase::{
-    Date, DateTime, FieldIOError, FieldIterator, FieldName, FieldValue, FieldWriter,
-    ReadableRecord, Reader, Record, TableWriterBuilder, Time, WritableRecord,
+    Date, DateTime, FieldError, FieldIterator, FieldName, FieldValue, FieldWriter, ReadableRecord,
+    Reader, Record, RecordIndex, TableWriterBuilder, Time, WritableRecord,
 };
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
@@ -110,7 +110,7 @@ struct Album {
 }
 
 impl ReadableRecord for Album {
-    fn read_using<R1, R2>(field_iterator: &mut FieldIterator<R1, R2>) -> Result<Self, FieldIOError>
+    fn read_using<R1, R2>(field_iterator: &mut FieldIterator<R1, R2>) -> Result<Self, FieldError>
     where
         R1: Read + Seek,
         R2: Read + Seek,
@@ -129,7 +129,7 @@ impl WritableRecord for Album {
     fn write_using<W: Write>(
         &self,
         field_writer: &mut FieldWriter<'_, W>,
-    ) -> Result<(), FieldIOError> {
+    ) -> Result<(), FieldError> {
         field_writer.write_next_field_value(&self.artist)?;
         field_writer.write_next_field_value(&self.name)?;
         field_writer.write_next_field_value(&self.released)?;
@@ -445,4 +445,43 @@ fn test_file_with_null_in_field_names() {
     for (expected_name, field) in expected_field_names.into_iter().zip(reader.fields().iter()) {
         assert_eq!(expected_name, field.name());
     }
+}
+
+// record_index() and field_index() contract tests
+
+#[test]
+fn test_header_error_has_no_record_index() {
+    let error = Reader::new(Cursor::new(vec![])).expect_err("expected error for empty input");
+    assert_eq!(error.record_index(), None);
+}
+
+#[test]
+fn test_deletion_flag_error_has_record_index_but_no_field_index() {
+    // Write 3 records so we can target a non-zero record index.
+    let mut dst = Cursor::new(Vec::<u8>::new());
+    let mut record = Record::default();
+    record.insert(
+        "name".to_owned(),
+        FieldValue::Character(Some("test".to_owned())),
+    );
+    TableWriterBuilder::new()
+        .add_character_field(FieldName::try_from("name").unwrap(), 10)
+        .build_with_dest(&mut dst)
+        .write_records(&[record.clone(), record.clone(), record])
+        .unwrap();
+
+    // Use the header to find the end of record #0, then truncate there so that
+    // reading the deletion flag of record #1 hits an unexpected EOF.
+    let bytes = dst.into_inner();
+    let header = *Reader::new(Cursor::new(bytes.clone())).unwrap().header();
+    let record_1_start = header.offset_to_first_record as usize + header.size_of_record as usize;
+    let truncated = bytes[..record_1_start].to_vec();
+
+    let error = Reader::new(Cursor::new(truncated))
+        .unwrap()
+        .read()
+        .expect_err("expected deletion flag error");
+
+    assert_eq!(error.record_index(), Some(RecordIndex(1)));
+    assert_eq!(error.field_index(), None);
 }


### PR DESCRIPTION
- Replace FieldIOError with FieldError, carrying field index, name and type
- Replace flat Error{record_num, field} with a layered context hierarchy (header → record → deletion flag → field)
- Add Error::record_index() and Error::field_index() accessors returning Option instead of using 0 has ambiguous value
- Implement Error::source() for our error types
- Fix DecodeError/EncodeError Display to not use debug formatting
- Fix FieldConversionError display: "from {actual} to {expected}" ordering
- Add narrowing integer conversions (i8/i16/u8/u16/u32/u64) to FieldValue initialy to make serde simpler, but also because it might be useful

