### PR TITLE
Add a decimal_places function.

### DIFF
--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -73,6 +73,10 @@ impl FieldInfo {
         self.field_length
     }
 
+    pub fn decimal_places(&self) -> u8 {
+        self.num_decimal_places
+    }
+
     pub(crate) fn new(name: FieldName, field_type: FieldType, length: u8) -> Self {
         Self {
             name: name.0,


### PR DESCRIPTION
I was working with a shapefile, that used a `FieldType::Numeric` where the `FieldInfo` has 0 decimal places.
I wanted to map this to some integer type, instead of some floating point type.